### PR TITLE
Angular: don't call 'detectChanges' on disposed elements

### DIFF
--- a/generator/angular-generator/expressions/component.ts
+++ b/generator/angular-generator/expressions/component.ts
@@ -36,6 +36,7 @@ import {
   compileType,
   capitalizeFirstLetter,
 } from "../../base-generator/utils/string";
+import { If } from "../../base-generator/expressions/conditions";
 
 const CUSTOM_VALUE_ACCESSOR_PROVIDER = "CUSTOM_VALUE_ACCESSOR_PROVIDER";
 
@@ -188,9 +189,7 @@ export class AngularComponent extends Component {
     }
     const statements = [new SimpleExpression(`this.__${name}=value;`)];
     if (onPushStrategy) {
-      statements.push(
-        new SimpleExpression(`this.changeDetection?.detectChanges();`)
-      );
+      statements.push(new SimpleExpression(`this._detectChanges();`));
     }
 
     onPushStrategy;
@@ -410,7 +409,7 @@ export class AngularComponent extends Component {
         [
           new SimpleExpression(`
           this.__${name} = slot;
-          this.changeDetection.detectChanges();
+          this._detectChanges();
         `),
         ],
         true
@@ -418,6 +417,32 @@ export class AngularComponent extends Component {
 
       members.push(new SetAccessor(decorators, [], name, parameters, body));
     });
+
+    members.push(
+      new Method(
+        undefined,
+        undefined,
+        undefined,
+        new Identifier("_detectChanges"),
+        undefined,
+        undefined,
+        [],
+        SyntaxKind.VoidKeyword,
+        new Block(
+          [
+            new SimpleExpression(`setTimeout(() => {
+            ${new If(
+              new SimpleExpression(
+                "this.changeDetection && !(this.changeDetection as ViewRef).destroyed"
+              ),
+              new SimpleExpression("this.changeDetection.detectChanges()")
+            )}
+          })`),
+          ],
+          true
+        )
+      )
+    );
 
     return members;
   }
@@ -456,7 +481,7 @@ export class AngularComponent extends Component {
             new Block(
               [
                 new SimpleExpression(`this.${member.name}=${member._name}`),
-                new SimpleExpression("this.changeDetection.detectChanges()"),
+                new SimpleExpression("this._detectChanges()"),
               ],
               false
             )
@@ -643,7 +668,7 @@ export class AngularComponent extends Component {
 
           ngDoCheckStatements.push(`
           if (${observableConditionArray.join("&&")}) {
-              this.changeDetection.detectChanges();
+              this._detectChanges();
               this.${updateEffectMethod}();
           }`);
         }
@@ -860,7 +885,7 @@ export class AngularComponent extends Component {
         
         writeValue(value: any): void {
             this.${this.modelProp.name} = value;
-            this.changeDetection.detectChanges();
+            this._detectChanges();
         }
     
         ${
@@ -978,7 +1003,7 @@ export class AngularComponent extends Component {
         constructorStatements.push(
           `this._${e.name}=(${parameters.join(",")}) => {
             this.${e.name}.emit(${parameters.map((p) => p.name).join(",")});
-            this.changeDetection.detectChanges();
+            this._detectChanges();
           }`
         );
         return `_${e.name}${compileType("any")}`;
@@ -1154,7 +1179,7 @@ export class AngularComponent extends Component {
           } else {
             const changeHandler = (value: ${m.type})=>{
               this.${m.name}Consumer = value
-              changeDetection.detectChanges();
+              this._detectChanges();
             };
             const subscription = ${m.name}.change.subscribe(changeHandler);
             this._destroyContext.push(()=>{
@@ -1195,6 +1220,7 @@ export class AngularComponent extends Component {
     const coreImports: string[] = [
       "ChangeDetectionStrategy",
       "ChangeDetectorRef",
+      "ViewRef",
     ];
     const constructorArguments: string[] = [
       "private changeDetection: ChangeDetectorRef",
@@ -1236,7 +1262,7 @@ export class AngularComponent extends Component {
       : "";
 
     if (this.members.some((m) => m.isNestedComp)) {
-      ngAfterViewInitStatements.push("this.changeDetection.detectChanges()");
+      ngAfterViewInitStatements.push("this._detectChanges()");
     }
 
     const external = this.getExternalFunctionNames();

--- a/generator/test/angular-generator.test.ts
+++ b/generator/test/angular-generator.test.ts
@@ -5011,13 +5011,19 @@ mocha.describe("Angular generator", function () {
       assert.strictEqual(
         getResult(component.toString()),
         getResult(`
-                import {Component,NgModule,ChangeDetectionStrategy,ChangeDetectorRef} from "@angular/core";
+                import {Component,NgModule,ChangeDetectionStrategy,ChangeDetectorRef,ViewRef} from "@angular/core";
                 import {CommonModule} from "@angular/common";
 
                 ${component.decorator}
                 export default class BaseWidget {
                     get __restAttributes(): any{
                         return {}
+                    }
+                    _detectChanges(): void {
+                      setTimeout(() => {
+                        if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+                          this.changeDetection.detectChanges();
+                      });
                     }
                     constructor(private changeDetection: ChangeDetectorRef) {}
                 }
@@ -5093,13 +5099,19 @@ mocha.describe("Angular generator", function () {
         assert.strictEqual(
           getResult(component.toString()),
           getResult(`
-                import {Component,NgModule,ChangeDetectionStrategy,ChangeDetectorRef} from "@angular/core";
+                import {Component,NgModule,ChangeDetectionStrategy,ChangeDetectorRef,ViewRef} from "@angular/core";
                 import {CommonModule} from "@angular/common";
                 
                 ${component.decorator}
                 export default class BaseWidget extends Input {
                     get __restAttributes(): any{
                         return {}
+                    }
+                    _detectChanges(): void {
+                      setTimeout(() => {
+                        if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+                          this.changeDetection.detectChanges();
+                      });
                     }
                     constructor(private changeDetection: ChangeDetectorRef) {
                       super();
@@ -5137,7 +5149,7 @@ mocha.describe("Angular generator", function () {
           getResult(setter[0].toString()),
           getResult(`set _p(p:any){
           this.p=p;
-          this.changeDetection.detectChanges();
+          this._detectChanges();
         }`)
         );
       });
@@ -5161,7 +5173,7 @@ mocha.describe("Angular generator", function () {
           getResult(setter[0].toString()),
           getResult(`set _p(p?:string){
           this.p=p;
-          this.changeDetection.detectChanges();
+          this._detectChanges();
         }`)
         );
       });
@@ -5185,7 +5197,7 @@ mocha.describe("Angular generator", function () {
           getResult(setter[0].toString()),
           getResult(`set _p(p:string){
           this.p=p;
-          this.changeDetection.detectChanges();
+          this._detectChanges();
         }`)
         );
       });
@@ -5208,7 +5220,7 @@ mocha.describe("Angular generator", function () {
           getResult(setter[0].toString()),
           getResult(`set _p(p:any){
           this.p=p;
-          this.changeDetection.detectChanges();
+          this._detectChanges();
         }`)
         );
       });
@@ -5232,7 +5244,7 @@ mocha.describe("Angular generator", function () {
           getResult(setter[0].toString()),
           getResult(`set _p(p:any){
           this.p=p;
-          this.changeDetection.detectChanges();
+          this._detectChanges();
         }`)
         );
       });
@@ -6115,7 +6127,7 @@ mocha.describe("Angular generator", function () {
             getResult(p1Setter?.toString() || ""),
             getResult(`set _p1(p1:any){
               this.p1=p1
-              this.changeDetection.detectChanges();
+              this._detectChanges();
             }`)
           );
 
@@ -6125,7 +6137,7 @@ mocha.describe("Angular generator", function () {
             getResult(`
                     set _p2(p2:any){
                         this.p2=p2;
-                        this.changeDetection.detectChanges();
+                        this._detectChanges();
                         if (this.__destroyEffects.length) {
                             this.__schedule_e();
                         }
@@ -6434,7 +6446,7 @@ mocha.describe("Angular generator", function () {
               getResult(`
                             set _p(p:any){
                                 this.p=p;
-                                this.changeDetection.detectChanges();
+                                this._detectChanges();
                                 this.__getterCache["name"] = undefined;
                             }`)
             );
@@ -6446,7 +6458,7 @@ mocha.describe("Angular generator", function () {
               getResult(`
                                 set _p1(p1:any){
                                     this.p1=p1;
-                                    this.changeDetection.detectChanges();
+                                    this._detectChanges();
                                 }`)
             );
           });

--- a/generator/test/test-cases/expected/angular/component-input.tsx
+++ b/generator/test/test-cases/expected/angular/component-input.tsx
@@ -15,6 +15,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -30,6 +31,12 @@ export default class Widget extends WidgetProps {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   constructor(private changeDetection: ChangeDetectorRef) {
     super();
@@ -38,7 +45,7 @@ export default class Widget extends WidgetProps {
     slot: ElementRef<HTMLDivElement>
   ) {
     this.__slotChildren = slot;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/component-pass.tsx
+++ b/generator/test/test-cases/expected/angular/component-pass.tsx
@@ -12,6 +12,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -39,6 +40,12 @@ import { CommonModule } from "@angular/common";
 export default class Widget extends WidgetProps {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/context.tsx
+++ b/generator/test/test-cases/expected/angular/context.tsx
@@ -44,6 +44,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -70,6 +71,12 @@ export default class Widget extends Props {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   _destroyContext: Array<() => void> = [];
@@ -98,7 +105,7 @@ export default class Widget extends Props {
     } else {
       const changeHandler = (value: number) => {
         this.contextConsumer = value;
-        changeDetection.detectChanges();
+        this._detectChanges();
       };
       const subscription = context.change.subscribe(changeHandler);
       this._destroyContext.push(() => {

--- a/generator/test/test-cases/expected/angular/default-options-empty.tsx
+++ b/generator/test/test-cases/expected/angular/default-options-empty.tsx
@@ -8,12 +8,14 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import {
   convertRulesToOptions,
   Rule,
 } from "../../../../component_declaration/default_options";
+
 type WidgetOptionRule = Rule<Partial<WidgetProps>>;
 
 const __defaultOptionRules: WidgetOptionRule[] = [
@@ -30,6 +32,12 @@ export function defaultOptions(rule: WidgetOptionRule) {
 export default class Widget extends WidgetProps {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/dx-inner-widget.tsx
+++ b/generator/test/test-cases/expected/angular/dx-inner-widget.tsx
@@ -11,6 +11,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   forwardRef,
   HostListener,
 } from "@angular/core";
@@ -35,13 +36,19 @@ export default class InnerWidget extends InnerWidgetProps
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   @HostListener("valueChange", ["$event"]) change() {}
   @HostListener("onBlur", ["$event"]) touched = () => {};
 
   writeValue(value: any): void {
     this.value = value;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 
   registerOnChange(fn: () => void): void {
@@ -57,11 +64,11 @@ export default class InnerWidget extends InnerWidgetProps
     super();
     this._onSelect = (e: any) => {
       this.onSelect.emit(e);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
     this._valueChange = (value: number) => {
       this.valueChange.emit(value);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
 

--- a/generator/test/test-cases/expected/angular/dx-widget-with-ref-prop.tsx
+++ b/generator/test/test-cases/expected/angular/dx-widget-with-ref-prop.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -20,6 +21,12 @@ import { CommonModule } from "@angular/common";
 export default class WidgetWithRefProp extends WidgetWithRefPropInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/dx-widget-with-template.tsx
+++ b/generator/test/test-cases/expected/angular/dx-widget-with-template.tsx
@@ -10,6 +10,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -25,6 +26,12 @@ import { CommonModule } from "@angular/common";
 export default class WidgetWithTemplate extends WidgetWithTemplateInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/effect.tsx
+++ b/generator/test/test-cases/expected/angular/effect.tsx
@@ -18,6 +18,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -48,6 +49,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   __destroyEffects: any[] = [];
@@ -102,12 +109,12 @@ export default class Widget extends WidgetInput {
     super();
     this._sChange = (s: number) => {
       this.sChange.emit(s);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
   set _i(i: number) {
     this.i = i;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
 
     if (this.__destroyEffects.length) {
       this.__schedule_setupData();
@@ -119,7 +126,7 @@ export default class Widget extends WidgetInput {
   }
   set _j(j: number) {
     this.j = j;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
 
     if (this.__destroyEffects.length) {
       this.__schedule_alwaysEffect();

--- a/generator/test/test-cases/expected/angular/effects-with-iterable.tsx
+++ b/generator/test/test-cases/expected/angular/effects-with-iterable.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -37,6 +38,12 @@ export default class Widget extends WidgetInput {
   __myMethod(): any {}
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   __destroyEffects: any[] = [];
@@ -134,7 +141,7 @@ export default class Widget extends WidgetInput {
       this.__destroyEffects.length &&
       this.__checkObservables(["propArray", "internalArray"])
     ) {
-      this.changeDetection.detectChanges();
+      this._detectChanges();
       this.__schedule_effectWithObservables();
     }
 
@@ -142,7 +149,7 @@ export default class Widget extends WidgetInput {
       this.__destroyEffects.length &&
       this.__checkObservables(["internalArray", "keys", "propArray"])
     ) {
-      this.changeDetection.detectChanges();
+      this._detectChanges();
       this.__schedule_alwaysEffect();
     }
   }
@@ -152,7 +159,7 @@ export default class Widget extends WidgetInput {
   }
   set _internalArray(internalArray: string[]) {
     this.internalArray = internalArray;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
     this.__cachedObservables["internalArray"] = [...internalArray];
 
     if (this.__destroyEffects.length) {
@@ -165,7 +172,7 @@ export default class Widget extends WidgetInput {
   }
   set _internalObject(internalObject: object) {
     this.internalObject = internalObject;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
 
     if (this.__destroyEffects.length) {
       this.__schedule_effect();
@@ -177,7 +184,7 @@ export default class Widget extends WidgetInput {
   }
   set _keys(keys: string[]) {
     this.keys = keys;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
     this.__cachedObservables["keys"] = [...keys];
 
     if (this.__destroyEffects.length) {
@@ -186,7 +193,7 @@ export default class Widget extends WidgetInput {
   }
   set _counter(counter: number) {
     this.counter = counter;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
 
     if (this.__destroyEffects.length) {
       this.__schedule_alwaysEffect();

--- a/generator/test/test-cases/expected/angular/empty-component.tsx
+++ b/generator/test/test-cases/expected/angular/empty-component.tsx
@@ -3,6 +3,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   Input,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
@@ -19,6 +20,12 @@ export default class Widget {
   @Input() width?: number;
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {}

--- a/generator/test/test-cases/expected/angular/export-default.tsx
+++ b/generator/test/test-cases/expected/angular/export-default.tsx
@@ -8,6 +8,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -19,6 +20,12 @@ import { CommonModule } from "@angular/common";
 export default class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/export-named-api-ref.tsx
+++ b/generator/test/test-cases/expected/angular/export-named-api-ref.tsx
@@ -5,6 +5,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -19,6 +20,12 @@ export class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/export-named.tsx
+++ b/generator/test/test-cases/expected/angular/export-named.tsx
@@ -8,6 +8,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -19,6 +20,12 @@ import { CommonModule } from "@angular/common";
 export class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/external-functions.tsx
+++ b/generator/test/test-cases/expected/angular/external-functions.tsx
@@ -17,6 +17,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -35,6 +36,12 @@ import { CommonModule } from "@angular/common";
 export default class Widget extends WidgetProps {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
   externalFunction: any = externalFunction;
   arrowFunction: any = arrowFunction;

--- a/generator/test/test-cases/expected/angular/forward-ref-child.tsx
+++ b/generator/test/test-cases/expected/angular/forward-ref-child.tsx
@@ -10,6 +10,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -49,6 +50,12 @@ export default class RefOnChildrenChild extends Props {
     ) => void) => {
       return (ref) => (this.nullableRefRef = ref);
     })());
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   __getterCache: {

--- a/generator/test/test-cases/expected/angular/forward-ref-parent.tsx
+++ b/generator/test/test-cases/expected/angular/forward-ref-parent.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -55,6 +56,12 @@ export default class RefOnChildrenParent extends Props {
     ) => void) => {
       return (ref) => (this.nullableRefRef = ref);
     })());
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   __destroyEffects: any[] = [];
@@ -104,7 +111,7 @@ export default class RefOnChildrenParent extends Props {
   }
   set _state(state: number) {
     this.state = state;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/forward-ref-template.tsx
+++ b/generator/test/test-cases/expected/angular/forward-ref-template.tsx
@@ -8,6 +8,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ElementRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
@@ -36,6 +37,12 @@ export default class RefOnChildrenTemplate extends Props {
     ) => void) => {
       return (ref) => (this.child = ref);
     })());
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   __destroyEffects: any[] = [];

--- a/generator/test/test-cases/expected/angular/getter-with-complex-type.tsx
+++ b/generator/test/test-cases/expected/angular/getter-with-complex-type.tsx
@@ -8,6 +8,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -32,6 +33,12 @@ export default class Widget extends Props {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   __getterCache: {
     g1?: number[];
@@ -48,7 +55,7 @@ export default class Widget extends Props {
   }
   set _i(i: number) {
     this.i = i;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
     this.__getterCache["g1"] = undefined;
   }
 }

--- a/generator/test/test-cases/expected/angular/globals-in-template.tsx
+++ b/generator/test/test-cases/expected/angular/globals-in-template.tsx
@@ -8,6 +8,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -19,6 +20,12 @@ import { CommonModule } from "@angular/common";
 export default class WidgetWithGlobals extends WidgetProps {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/implements.tsx
+++ b/generator/test/test-cases/expected/angular/implements.tsx
@@ -17,6 +17,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -29,6 +30,12 @@ export default class Widget extends WidgetInput {
   __onClick(): void {}
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/import-component-named.tsx
+++ b/generator/test/test-cases/expected/angular/import-component-named.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -20,6 +21,12 @@ import { CommonModule } from "@angular/common";
 export default class Child extends ChildInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/import-component.tsx
+++ b/generator/test/test-cases/expected/angular/import-component.tsx
@@ -10,6 +10,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -27,20 +28,26 @@ export default class Child extends ChildInput {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   _onClick: any;
   constructor(private changeDetection: ChangeDetectorRef) {
     super();
     this._onClick = (a: number) => {
       this.onClick.emit(a);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
   @ViewChild("slotChildren") set slotChildren(
     slot: ElementRef<HTMLDivElement>
   ) {
     this.__slotChildren = slot;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/internal-state.tsx
+++ b/generator/test/test-cases/expected/angular/internal-state.tsx
@@ -3,6 +3,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -19,11 +20,17 @@ export default class Widget {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   constructor(private changeDetection: ChangeDetectorRef) {}
   set __hovered(_hovered: Boolean) {
     this._hovered = _hovered;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/jsx-function-in-view.tsx
+++ b/generator/test/test-cases/expected/angular/jsx-function-in-view.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -33,6 +34,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/list.tsx
+++ b/generator/test/test-cases/expected/angular/list.tsx
@@ -8,6 +8,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -23,6 +24,12 @@ import { CommonModule } from "@angular/common";
 export default class List extends ListInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   _trackBy_items_0(_index: number, item: any) {

--- a/generator/test/test-cases/expected/angular/method-use-apiref.tsx
+++ b/generator/test/test-cases/expected/angular/method-use-apiref.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
@@ -25,6 +26,12 @@ export default class WidgetWithApiRef extends WidgetWithApiRefInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/method-without-decorator.tsx
+++ b/generator/test/test-cases/expected/angular/method-without-decorator.tsx
@@ -5,6 +5,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -23,6 +24,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/method.tsx
+++ b/generator/test/test-cases/expected/angular/method.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -29,6 +30,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/model-value-disabled.tsx
+++ b/generator/test/test-cases/expected/angular/model-value-disabled.tsx
@@ -12,6 +12,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   forwardRef,
   HostListener,
 } from "@angular/core";
@@ -34,13 +35,19 @@ export default class ModelWidget extends ModelWidgetInput
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   @HostListener("valueChange", ["$event"]) change() {}
   @HostListener("onBlur", ["$event"]) touched = () => {};
 
   writeValue(value: any): void {
     this.value = value;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 
   setDisabledState(isDisabled: boolean): void {
@@ -60,11 +67,11 @@ export default class ModelWidget extends ModelWidgetInput
     super();
     this._valueChange = (value: boolean) => {
       this.valueChange.emit(value);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
     this._notValueChange = (notValue: boolean) => {
       this.notValueChange.emit(notValue);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
 }

--- a/generator/test/test-cases/expected/angular/model.tsx
+++ b/generator/test/test-cases/expected/angular/model.tsx
@@ -13,6 +13,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   forwardRef,
   HostListener,
 } from "@angular/core";
@@ -35,13 +36,19 @@ export default class ModelWidget extends ModelWidgetInput
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   @HostListener("modelStatePropChange", ["$event"]) change() {}
   @HostListener("onBlur", ["$event"]) touched = () => {};
 
   writeValue(value: any): void {
     this.modelStateProp = value;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 
   registerOnChange(fn: () => void): void {
@@ -58,15 +65,15 @@ export default class ModelWidget extends ModelWidgetInput
     super();
     this._baseStatePropChange = (stateProp: boolean) => {
       this.baseStatePropChange.emit(stateProp);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
     this._modelStatePropChange = (modelStateProp: boolean) => {
       this.modelStatePropChange.emit(modelStateProp);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
     this._valueChange = (value: boolean) => {
       this.valueChange.emit(value);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
 }

--- a/generator/test/test-cases/expected/angular/nested.tsx
+++ b/generator/test/test-cases/expected/angular/nested.tsx
@@ -5,6 +5,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   Input,
   ContentChildren,
   QueryList,
@@ -152,10 +153,16 @@ export default class Widget extends PickedProps {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
   CustomColumnComponent: any = CustomColumnComponent;
 
   ngAfterViewInit() {
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {
@@ -163,11 +170,11 @@ export default class Widget extends PickedProps {
   }
   @Input() set columns(value: Array<DxWidgetColumn | string> | undefined) {
     this.__columns = value;
-    this.changeDetection?.detectChanges();
+    this._detectChanges();
   }
   @Input() set editing(value: DxWidgetEditing | undefined) {
     this.__editing = value;
-    this.changeDetection?.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/pick-props.tsx
+++ b/generator/test/test-cases/expected/angular/pick-props.tsx
@@ -11,6 +11,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -30,13 +31,19 @@ export default class Widget extends WidgetProps {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   constructor(private changeDetection: ChangeDetectorRef) {
     super();
   }
   set _innerData(innerData: Options) {
     this.innerData = innerData;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/portal.tsx
+++ b/generator/test/test-cases/expected/angular/portal.tsx
@@ -8,6 +8,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ComponentFactoryResolver,
   ApplicationRef,
@@ -103,6 +104,12 @@ export default class Widget extends WidgetProps {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   __destroyEffects: any[] = [];
   __viewCheckedSubscribeEvent: Array<() => void> = [];
@@ -124,7 +131,7 @@ export default class Widget extends WidgetProps {
   }
   set _rendered(rendered: boolean) {
     this.rendered = rendered;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/props.tsx
+++ b/generator/test/test-cases/expected/angular/props.tsx
@@ -10,6 +10,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -27,13 +28,19 @@ export default class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   _onClick: any;
   constructor(private changeDetection: ChangeDetectorRef) {
     super();
     this._onClick = (a: number) => {
       this.onClick.emit(a);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
 }

--- a/generator/test/test-cases/expected/angular/refs-as-props.tsx
+++ b/generator/test/test-cases/expected/angular/refs-as-props.tsx
@@ -11,6 +11,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -37,6 +38,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/refs.tsx
+++ b/generator/test/test-cases/expected/angular/refs.tsx
@@ -3,6 +3,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -36,6 +37,12 @@ export default class Widget {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {}

--- a/generator/test/test-cases/expected/angular/required-props.tsx
+++ b/generator/test/test-cases/expected/angular/required-props.tsx
@@ -11,12 +11,14 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import {
   convertRulesToOptions,
   Rule,
 } from "../../../../component_declaration/default_options";
+
 type WidgetOptionRule = Rule<Partial<WidgetInput>>;
 
 const __defaultOptionRules: WidgetOptionRule[] = [];
@@ -38,6 +40,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/slots.tsx
+++ b/generator/test/test-cases/expected/angular/slots.tsx
@@ -17,6 +17,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -40,6 +41,12 @@ export default class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   constructor(private changeDetection: ChangeDetectorRef) {
     super();
@@ -48,13 +55,13 @@ export default class Widget extends WidgetInput {
     slot: ElementRef<HTMLDivElement>
   ) {
     this.__slotNamedSlot = slot;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
   @ViewChild("slotChildren") set slotChildren(
     slot: ElementRef<HTMLDivElement>
   ) {
     this.__slotChildren = slot;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/spread-attribute-with-custom-component.tsx
+++ b/generator/test/test-cases/expected/angular/spread-attribute-with-custom-component.tsx
@@ -6,6 +6,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -25,6 +26,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/spread-attribute-without-ref.tsx
+++ b/generator/test/test-cases/expected/angular/spread-attribute-without-ref.tsx
@@ -5,6 +5,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -21,6 +22,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
   @ViewChild("_auto_ref_0", { static: false }) _auto_ref_0?: ElementRef<
     HTMLDivElement

--- a/generator/test/test-cases/expected/angular/spread-attribute.tsx
+++ b/generator/test/test-cases/expected/angular/spread-attribute.tsx
@@ -5,6 +5,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   ViewChild,
   ElementRef,
 } from "@angular/core";
@@ -26,6 +27,12 @@ export default class Widget extends WidgetInput {
   }
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
   @ViewChild("_auto_ref_0", { static: false }) _auto_ref_0?: ElementRef<
     HTMLDivElement

--- a/generator/test/test-cases/expected/angular/spread-props-attribute.tsx
+++ b/generator/test/test-cases/expected/angular/spread-props-attribute.tsx
@@ -11,6 +11,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
   forwardRef,
   HostListener,
 } from "@angular/core";
@@ -36,13 +37,19 @@ export default class Widget extends WidgetInput
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   @HostListener("valueChange", ["$event"]) change() {}
   @HostListener("onBlur", ["$event"]) touched = () => {};
 
   writeValue(value: any): void {
     this.value = value;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 
   registerOnChange(fn: () => void): void {
@@ -57,7 +64,7 @@ export default class Widget extends WidgetInput
     super();
     this._valueChange = (value: boolean) => {
       this.valueChange.emit(value);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
 }

--- a/generator/test/test-cases/expected/angular/state-short-operator.tsx
+++ b/generator/test/test-cases/expected/angular/state-short-operator.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -32,18 +33,24 @@ export default class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   _propStateChange: any;
   constructor(private changeDetection: ChangeDetectorRef) {
     super();
     this._propStateChange = (propState: number) => {
       this.propStateChange.emit(propState);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
   set _innerState(innerState: number) {
     this.innerState = innerState;
-    this.changeDetection.detectChanges();
+    this._detectChanges();
   }
 }
 @NgModule({

--- a/generator/test/test-cases/expected/angular/state.tsx
+++ b/generator/test/test-cases/expected/angular/state.tsx
@@ -14,6 +14,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -45,6 +46,12 @@ export default class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   _state1Change: any;
   _state2Change: any;
@@ -53,15 +60,15 @@ export default class Widget extends WidgetInput {
     super();
     this._state1Change = (state1: boolean) => {
       this.state1Change.emit(state1);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
     this._state2Change = (state2: boolean) => {
       this.state2Change.emit(state2);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
     this._statePropChange = (stateProp: boolean) => {
       this.statePropChange.emit(stateProp);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
 }

--- a/generator/test/test-cases/expected/angular/template-pass.tsx
+++ b/generator/test/test-cases/expected/angular/template-pass.tsx
@@ -9,6 +9,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -41,6 +42,12 @@ import { CommonModule } from "@angular/common";
 export default class Widget extends WidgetProps {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/template-transit.tsx
+++ b/generator/test/test-cases/expected/angular/template-transit.tsx
@@ -13,6 +13,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -27,6 +28,12 @@ import { CommonModule } from "@angular/common";
 export default class TemplateTransitWidget extends TemplateTransitWidgetInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/template.tsx
+++ b/generator/test/test-cases/expected/angular/template.tsx
@@ -12,6 +12,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -45,6 +46,12 @@ import { CommonModule } from "@angular/common";
 export default class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {

--- a/generator/test/test-cases/expected/angular/two-way-props.tsx
+++ b/generator/test/test-cases/expected/angular/two-way-props.tsx
@@ -10,6 +10,7 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
@@ -34,13 +35,19 @@ export default class Widget extends WidgetInput {
   get __restAttributes(): any {
     return {};
   }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
+  }
 
   _selectedChange: any;
   constructor(private changeDetection: ChangeDetectorRef) {
     super();
     this._selectedChange = (selected: boolean) => {
       this.selectedChange.emit(selected);
-      this.changeDetection.detectChanges();
+      this._detectChanges();
     };
   }
 }

--- a/generator/test/test-cases/expected/angular/use-external-component-bindings.tsx
+++ b/generator/test/test-cases/expected/angular/use-external-component-bindings.tsx
@@ -4,12 +4,14 @@ import {
   NgModule,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  ViewRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import {
   convertRulesToOptions,
   Rule,
 } from "../../../../component_declaration/default_options";
+
 type WidgetOptionRule = Rule<Partial<Props>>;
 
 const __defaultOptionRules: WidgetOptionRule[] = [];
@@ -25,6 +27,12 @@ export function defaultOptions(rule: WidgetOptionRule) {
 export default class Widget extends Props {
   get __restAttributes(): any {
     return {};
+  }
+  _detectChanges(): void {
+    setTimeout(() => {
+      if (this.changeDetection && !(this.changeDetection as ViewRef).destroyed)
+        this.changeDetection.detectChanges();
+    });
   }
 
   constructor(private changeDetection: ChangeDetectorRef) {


### PR DESCRIPTION
Fix #377 