### PR TITLE
Set up Node in the publication action

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -5,6 +5,8 @@ on:
       - master
     paths:
       - 'packages/*/package.json'
+env:
+  nodeVersion: 12.x
 
 jobs:
 
@@ -80,6 +82,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.nodeVersion }}
+          registry-url: https://registry.npmjs.org/
 
       - uses: actions/download-artifact@master
         with:


### PR DESCRIPTION
npm publish doesn't work in this repo somehow. Let's try to add an additional step with node setting up