### PR TITLE
Change `target` for vdom packages

### DIFF
--- a/packages/vdom/src/base_component.ts
+++ b/packages/vdom/src/base_component.ts
@@ -27,7 +27,7 @@ export class BaseInfernoComponent<
   _pendingContext: any = this.context;
 
   componentWillReceiveProps(_: any, context: any) {
-    this._pendingContext = context || {};
+    this._pendingContext = context ?? {};
   }
 
   shouldComponentUpdate(nextProps: P, nextState: S) {

--- a/packages/vdom/tsconfig.esm.build.json
+++ b/packages/vdom/tsconfig.esm.build.json
@@ -3,6 +3,6 @@
     "compilerOptions": {
         "module": "esnext",
         "outDir": "dist/esm",
-        "target": "esnext"
+        "target": "ES6"
     }
 }


### PR DESCRIPTION
CJS - target: `ES5` (IE11 support)
ESM - target: `ES6` (some used features from `esnext` are not available in webpack)