### PR TITLE
React, Preact: Fix missing import of RefObject

### DIFF
--- a/packages/preact-generator/src/preact-generator.ts
+++ b/packages/preact-generator/src/preact-generator.ts
@@ -518,7 +518,9 @@ export class ImportDeclaration extends BaseImportDeclaration {
     if (this.has('Portal')) {
       compat.push('createPortal');
     }
-
+    if (this.has('RefObject') || this.has('Ref') || this.has('ForwardRef')) {
+      preact.push('RefObject');
+    }
     if (preact.length) {
       result.push(`import { ${preact} } from "preact"`);
     }

--- a/packages/react-generator/src/expressions/import-declaration.ts
+++ b/packages/react-generator/src/expressions/import-declaration.ts
@@ -9,6 +9,10 @@ export class ImportDeclaration extends BaseImportDeclaration {
       react.push('createContext');
     }
 
+    if (this.has('RefObject') || this.has('Ref') || this.has('ForwardRef')) {
+      react.push('MutableRefObject');
+    }
+
     if (this.has('Portal')) {
       reactDom.push('createPortal');
     }

--- a/packages/react-generator/src/expressions/react-component.ts
+++ b/packages/react-generator/src/expressions/react-component.ts
@@ -353,14 +353,6 @@ export class ReactComponent extends Component {
       hooks.push('useRef');
     }
 
-    if (
-      this.refs.length
-      || this.apiRefs.length
-      || this.members.some((m) => m.isRefProp || m.isForwardRefProp)
-    ) {
-      core.push(this.REF_OBJECT_TYPE);
-    }
-
     if (this.members.filter((a) => a.isApiMethod).length) {
       hooks.push('useImperativeHandle');
       compats.push('forwardRef');

--- a/packages/tests/unit-tests/preact-generator.test.ts
+++ b/packages/tests/unit-tests/preact-generator.test.ts
@@ -371,6 +371,47 @@ mocha.describe("import Components", function () {
     }
   );
 });
+mocha.describe("Import_Declaration", function(){
+  this.beforeEach(function () {
+    generator.setContext({ dirname: path.resolve(__dirname) });
+  });
+
+  this.afterEach(function () {
+    generator.setContext(null);
+  });
+  mocha.it("generates import for RefObject", function(){
+    const importDeclaration = generator.createImportDeclaration(
+      undefined,
+      undefined,
+      generator.createImportClause(
+        undefined,
+        generator.createNamedImports([
+          generator.createImportSpecifier(
+            undefined,
+            generator.createIdentifier("ComponentBindings")
+          ),
+          generator.createImportSpecifier(
+            undefined,
+            generator.createIdentifier("Ref")
+          ),
+          generator.createImportSpecifier(
+            undefined,
+            generator.createIdentifier("RefObject")
+          )
+        ]),
+        false
+      ),
+      generator.createStringLiteral("@devextreme-generator/declarations")
+    );
+    assert.strictEqual(
+      getResult(importDeclaration.toString()),
+      getResult(
+        `import { RefObject } from "preact"`
+      )
+    );
+  })
+})
+
 
 mocha.describe("preact-generator: jQuery generation", function () {
   const testGenerator = createTestGenerator("preact");

--- a/packages/tests/unit-tests/react-generator.test.ts
+++ b/packages/tests/unit-tests/react-generator.test.ts
@@ -3411,3 +3411,44 @@ mocha.describe("Default_options", function () {
     }
   );
 });
+
+mocha.describe("Import_Declaration", function(){
+  this.beforeEach(function () {
+    generator.setContext({ dirname: path.resolve(__dirname) });
+  });
+
+  this.afterEach(function () {
+    generator.setContext(null);
+  });
+  mocha.it("generates import for RefObject", function(){
+    const importDeclaration = generator.createImportDeclaration(
+      undefined,
+      undefined,
+      generator.createImportClause(
+        undefined,
+        generator.createNamedImports([
+          generator.createImportSpecifier(
+            undefined,
+            generator.createIdentifier("ComponentBindings")
+          ),
+          generator.createImportSpecifier(
+            undefined,
+            generator.createIdentifier("Ref")
+          ),
+          generator.createImportSpecifier(
+            undefined,
+            generator.createIdentifier("RefObject")
+          )
+        ]),
+        false
+      ),
+      generator.createStringLiteral("@devextreme-generator/declarations")
+    );
+    assert.strictEqual(
+      getResult(importDeclaration.toString()),
+      getResult(
+        `import { MutableRefObject } from "react"`
+      )
+    );
+  })
+})

--- a/packages/tests/unit-tests/test-cases/expected/preact/method-use-apiref.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/preact/method-use-apiref.tsx
@@ -1,19 +1,19 @@
+import { RefObject } from "preact";
 import BaseWidget from "./method";
 function view(viewModel: WidgetWithApiRef) {
   return (
     <BaseWidget
-      ref={viewModel.baseRef}
-      prop1={viewModel.props.prop1}
+    ref={viewModel.baseRef}
+    prop1={viewModel.props.prop1}
     ></BaseWidget>
-  );
-}
-
-export declare type WidgetWithApiRefInputType = {
-  prop1?: number;
-};
-const WidgetWithApiRefInput: WidgetWithApiRefInputType = {};
-import * as Preact from "preact";
-import { RefObject } from "preact";
+    );
+  }
+  
+  export declare type WidgetWithApiRefInputType = {
+    prop1?: number;
+  };
+  const WidgetWithApiRefInput: WidgetWithApiRefInputType = {};
+  import * as Preact from "preact";
 import { useCallback, useRef, useImperativeHandle } from "preact/hooks";
 import { forwardRef } from "preact/compat";
 

--- a/packages/tests/unit-tests/test-cases/expected/preact/portal.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/preact/portal.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "preact";
 import { createPortal } from "preact/compat";
 function view(model: Widget) {
   return (
@@ -20,7 +21,6 @@ export declare type WidgetPropsType = {
 };
 export const WidgetProps: WidgetPropsType = {};
 import * as Preact from "preact";
-import { RefObject } from "preact";
 import { useState, useCallback, useEffect } from "preact/hooks";
 
 declare type PortalProps = {

--- a/packages/tests/unit-tests/test-cases/expected/preact/refs.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/preact/refs.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from "preact";
 function view(viewModel: Widget) {
   return (
     <div ref={viewModel.divRef}>
@@ -15,7 +16,6 @@ export declare type WidgetPropsType = {
 };
 const WidgetProps: WidgetPropsType = {} as any as WidgetPropsType;
 import * as Preact from "preact";
-import { RefObject } from "preact";
 import { useCallback, useRef } from "preact/hooks";
 
 declare type RestProps = {

--- a/packages/tests/unit-tests/test-cases/expected/react/dx-widget-with-ref-prop.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/dx-widget-with-ref-prop.tsx
@@ -1,10 +1,12 @@
+import { MutableRefObject } from "react";
+
 export declare type WidgetWithRefPropInputType = {
   parentRef?: MutableRefObject<any>;
   nullableRef?: MutableRefObject<any>;
 };
 export const WidgetWithRefPropInput: WidgetWithRefPropInputType = {};
 import * as React from "react";
-import { useCallback, MutableRefObject } from "react";
+import { useCallback } from "react";
 
 declare type RestProps = {
   className?: string;

--- a/packages/tests/unit-tests/test-cases/expected/react/forward-ref-child.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/forward-ref-child.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 function view({ props: { childRef, nullableRef } }: RefOnChildrenChild) {
   return (
     <div ref={childRef}>
@@ -13,7 +14,7 @@ export declare type PropsType = {
 };
 const Props: PropsType = {} as any as PropsType;
 import * as React from "react";
-import { useCallback, MutableRefObject } from "react";
+import { useCallback } from "react";
 
 declare type RestProps = {
   className?: string;

--- a/packages/tests/unit-tests/test-cases/expected/react/forward-ref-parent.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/forward-ref-parent.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 import Child from "./forward-ref-child";
 function view({
   child,
@@ -14,13 +15,7 @@ export declare type PropsType = {
 };
 const Props: PropsType = {};
 import * as React from "react";
-import {
-  useState,
-  useCallback,
-  useEffect,
-  useRef,
-  MutableRefObject,
-} from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 
 declare type RestProps = {
   className?: string;

--- a/packages/tests/unit-tests/test-cases/expected/react/forward-ref-template.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/forward-ref-template.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 function view(model: RefOnChildrenTemplate) {
   return (
     <React.Fragment>
@@ -13,7 +14,7 @@ export declare type PropsType = {
 };
 const Props: PropsType = {} as any as PropsType;
 import * as React from "react";
-import { useCallback, useEffect, useRef, MutableRefObject } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 declare type RestProps = {
   className?: string;

--- a/packages/tests/unit-tests/test-cases/expected/react/method-use-apiref.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/method-use-apiref.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 import BaseWidget from "./method";
 function view(viewModel: WidgetWithApiRef) {
   return (
@@ -14,13 +15,7 @@ export declare type WidgetWithApiRefInputType = {
 const WidgetWithApiRefInput: WidgetWithApiRefInputType = {};
 import { WidgetRef as BaseWidgetRef } from "./method";
 import * as React from "react";
-import {
-  useCallback,
-  useRef,
-  useImperativeHandle,
-  forwardRef,
-  MutableRefObject,
-} from "react";
+import { useCallback, useRef, useImperativeHandle, forwardRef } from "react";
 
 export type WidgetWithApiRefRef = { getSomething: () => string };
 declare type RestProps = {

--- a/packages/tests/unit-tests/test-cases/expected/react/method.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/method.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 function view(viewModel: Widget) {
   return <div ref={viewModel.divRef}></div>;
 }
@@ -8,13 +9,7 @@ export declare type WidgetInputType = {
 };
 const WidgetInput: WidgetInputType = {};
 import * as React from "react";
-import {
-  useCallback,
-  useRef,
-  useImperativeHandle,
-  forwardRef,
-  MutableRefObject,
-} from "react";
+import { useCallback, useRef, useImperativeHandle, forwardRef } from "react";
 
 export type WidgetRef = {
   getHeight: (p: number, p1: any) => string;

--- a/packages/tests/unit-tests/test-cases/expected/react/nested-props-and-component.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/nested-props-and-component.tsx
@@ -1,12 +1,6 @@
-function view(model: undefWidget) {
-  return (
-    <div>
-      <div>
-        Nested:
-        {model.nested}
-      </div>
-    </div>
-  );
+import { MutableRefObject } from "react";
+function view(model: UndefWidget) {
+  return <div></div>;
 }
 
 export declare type FakeNestedType = {
@@ -25,7 +19,7 @@ export const WidgetProps: WidgetPropsType = {
   __defaultNestedValues: { anotherNestedPropInit: [FakeNested] },
 };
 import * as React from "react";
-import { useCallback } from "react";
+import { useState, useCallback } from "react";
 
 function __collectChildren<T>(children: React.ReactNode): T[] {
   return (

--- a/packages/tests/unit-tests/test-cases/expected/react/nested-props-and-component.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/nested-props-and-component.tsx
@@ -1,6 +1,12 @@
-import { MutableRefObject } from "react";
-function view(model: UndefWidget) {
-  return <div></div>;
+function view(model: undefWidget) {
+  return (
+    <div>
+      <div>
+        Nested:
+        {model.nested}
+      </div>
+    </div>
+  );
 }
 
 export declare type FakeNestedType = {
@@ -19,7 +25,7 @@ export const WidgetProps: WidgetPropsType = {
   __defaultNestedValues: { anotherNestedPropInit: [FakeNested] },
 };
 import * as React from "react";
-import { useState, useCallback } from "react";
+import { useCallback } from "react";
 
 function __collectChildren<T>(children: React.ReactNode): T[] {
   return (

--- a/packages/tests/unit-tests/test-cases/expected/react/portal.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/portal.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 import { createPortal } from "react-dom";
 function view(model: Widget) {
   return (
@@ -20,7 +21,7 @@ export declare type WidgetPropsType = {
 };
 export const WidgetProps: WidgetPropsType = {};
 import * as React from "react";
-import { useState, useCallback, useEffect, MutableRefObject } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 declare type PortalProps = {
   container?: HTMLElement | null;

--- a/packages/tests/unit-tests/test-cases/expected/react/refs-as-props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/refs-as-props.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 import WidgetWithRefProp from "./dx-widget-with-ref-prop";
 function view(viewModel: Widget) {
   return (
@@ -15,7 +16,7 @@ export declare type WidgetInputType = {
 };
 const WidgetInput: WidgetInputType = {};
 import * as React from "react";
-import { useCallback, useRef, MutableRefObject } from "react";
+import { useCallback, useRef } from "react";
 
 declare type RestProps = {
   className?: string;

--- a/packages/tests/unit-tests/test-cases/expected/react/refs.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/refs.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 function view(viewModel: Widget) {
   return (
     <div ref={viewModel.divRef}>
@@ -15,7 +16,7 @@ export declare type WidgetPropsType = {
 };
 const WidgetProps: WidgetPropsType = {} as any as WidgetPropsType;
 import * as React from "react";
-import { useCallback, useRef, MutableRefObject } from "react";
+import { useCallback, useRef } from "react";
 
 declare type RestProps = {
   className?: string;

--- a/packages/tests/unit-tests/test-cases/expected/react/same-type-ref.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/same-type-ref.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 import BaseWidget from "./method";
 function view(viewModel: Widget) {
   return <BaseWidget></BaseWidget>;
@@ -9,7 +10,7 @@ export declare type WidgetInputType = {
 const WidgetInput: WidgetInputType = {};
 import { WidgetRef as BaseWidgetRef } from "./method";
 import * as React from "react";
-import { useCallback, useRef, MutableRefObject } from "react";
+import { useCallback, useRef } from "react";
 
 declare type RestProps = {
   className?: string;


### PR DESCRIPTION
Cherry picked from https://github.com/DevExpress/devextreme-renovation/commit/ba8fb7607d6e604ae94fd81fa35cfc289dcb330f