### PR TITLE
Angular, Inferno: Fix redundant caching getters for base class (#741)

### DIFF
--- a/packages/angular-generator/src/expressions/class-members/get-accessor.ts
+++ b/packages/angular-generator/src/expressions/class-members/get-accessor.ts
@@ -3,20 +3,17 @@ import {
   Binary,
   Block,
   Call,
-  Decorators,
   GetAccessor as BaseGetAccessor,
   Identifier,
   isComplexType,
-  Parameter,
   Paren,
   ReturnStatement,
   SimpleExpression,
   SyntaxKind,
   TypeExpression,
   Expression,
+  toStringOptions,
 } from '@devextreme-generator/core';
-
-import { Decorator } from '../decorator';
 
 export const compileGetterCache = (
   name: Identifier,
@@ -60,21 +57,6 @@ export const compileGetterCache = (
   ];
 };
 export class GetAccessor extends BaseGetAccessor {
-  constructor(
-    decorators: Decorator[] | undefined,
-    modifiers: string[] | undefined,
-    name: Identifier,
-    parameters: Parameter[],
-    type?: TypeExpression | string,
-    body?: Block,
-  ) {
-    const isProvider = decorators?.some((d) => d.name === Decorators.Provider);
-    if (body && ((type && isComplexType(type)) || isProvider)) {
-      body.statements = compileGetterCache(name, type, body, isProvider);
-    }
-    super(decorators, modifiers, name, parameters, type, body);
-  }
-
   isMemorized(): boolean {
     return isComplexType(this.type) || this.isProvider;
   }
@@ -91,5 +73,14 @@ export class GetAccessor extends BaseGetAccessor {
       return false;
     }
     return super.canBeDestructured;
+  }
+
+  toString(options?: toStringOptions): string {
+    if (options?.isComponent
+       && this.body
+       && ((this.type && isComplexType(this.type)) || this.isProvider)) {
+      this.body.statements = compileGetterCache(this._name, this.type, this.body, this.isProvider);
+    }
+    return super.toString(options);
   }
 }

--- a/packages/angular-generator/src/expressions/component.ts
+++ b/packages/angular-generator/src/expressions/component.ts
@@ -1559,6 +1559,7 @@ export class AngularComponent extends Component {
       componentContext: SyntaxKind.ThisKeyword,
       newComponentContext: SyntaxKind.ThisKeyword,
       forwardRefs: decoratorToStringOptions.forwardRefs,
+      isComponent: true,
     }))
     .filter((m) => m)
     .join('\n')}

--- a/packages/core-generator/src/expressions/class-members.ts
+++ b/packages/core-generator/src/expressions/class-members.ts
@@ -337,7 +337,7 @@ export class GetAccessor extends Method {
     return `${this.processComponentContext(componentContext)}${this.name}`;
   }
 
-  toString(options?: toStringOptions) {
+  toString(options?: toStringOptions): string {
     return `${this.modifiers.join(' ')} get ${this.name}()${compileType(
       this.type.toString(),
     )}${this.body?.toString(options)}`;

--- a/packages/core-generator/src/types.ts
+++ b/packages/core-generator/src/types.ts
@@ -26,6 +26,7 @@ export interface toStringOptions {
   jsxComponent?: Component;
   usePropsSpace?: boolean;
   componentInputs?: ComponentInput[];
+  isComponent?: boolean;
 }
 
 export type VariableExpression = {

--- a/packages/inferno-generator/src/expressions/class-members/get-accessor.ts
+++ b/packages/inferno-generator/src/expressions/class-members/get-accessor.ts
@@ -1,37 +1,28 @@
 import { GetAccessor as ReactGetAccessor } from '@devextreme-generator/react';
 import {
   isComplexType,
-  Decorator,
-  Identifier,
-  Parameter,
-  TypeExpression,
-  Block,
-  Decorators,
+  toStringOptions,
 } from '@devextreme-generator/core';
 
 import { compileGetterCache } from '@devextreme-generator/angular';
 
 export class GetAccessor extends ReactGetAccessor {
-  constructor(
-    decorators: Decorator[] | undefined,
-    modifiers: string[] | undefined,
-    name: Identifier,
-    parameters: Parameter[],
-    type?: TypeExpression | string,
-    body?: Block,
-  ) {
-    const isProvider = decorators?.some((d) => d.name === Decorators.Provider);
-    if (body && ((type && isComplexType(type)) || isProvider)) {
-      body.statements = compileGetterCache(name, type, body, isProvider, false);
-    }
-    super(decorators, modifiers, name, parameters, type, body);
-  }
-
   isMemorized(): boolean {
     return isComplexType(this.type) || this.isProvider;
   }
 
   getter(componentContext?: string): string {
     return super.getter(componentContext).replace('()', '');
+  }
+
+  toString(options?: toStringOptions): string {
+    if (options?.isComponent
+       && this.body
+       && ((this.type && isComplexType(this.type)) || this.isProvider)) {
+      this.body.statements = compileGetterCache(
+        this._name, this.type, this.body, this.isProvider, false,
+      );
+    }
+    return super.toString(options);
   }
 }

--- a/packages/inferno-generator/src/expressions/inferno-component.ts
+++ b/packages/inferno-generator/src/expressions/inferno-component.ts
@@ -75,6 +75,7 @@ export class InfernoComponent extends PreactComponent {
     return {
       ...super.getToStringOptions(),
       newComponentContext: 'this',
+      isComponent: true,
     };
   }
 

--- a/packages/tests/unit-tests/angular-generator.test.ts
+++ b/packages/tests/unit-tests/angular-generator.test.ts
@@ -8145,7 +8145,7 @@ mocha.describe("Angular generator", function () {
           );
 
           assert.strictEqual(
-            getResult(getter.toString()),
+            getResult(getter.toString({members: [], isComponent: true})),
             getResult(`get name():string[]{
                             if(this.__getterCache["name"]!==undefined){
                                 return this.__getterCache["name"]
@@ -8192,7 +8192,7 @@ mocha.describe("Angular generator", function () {
           );
 
           assert.strictEqual(
-            getResult(getter.toString()),
+            getResult(getter.toString({members: [], isComponent:true})),
             getResult(`get name():string{
                             return result;
                         }`)
@@ -8214,7 +8214,7 @@ mocha.describe("Angular generator", function () {
           );
 
           assert.strictEqual(
-            getResult(getter.toString()),
+            getResult(getter.toString({members: [], isComponent:true})),
             getResult(`get name():'1'|'2'{
                             return result;
                         }`)
@@ -8234,7 +8234,7 @@ mocha.describe("Angular generator", function () {
           );
 
           assert.strictEqual(
-            getResult(getter.toString()),
+            getResult(getter.toString({members: [], isComponent:true})),
             getResult(`get name():'1'|{}{
                             if(this.__getterCache["name"]!==undefined){
                                 return this.__getterCache["name"];
@@ -8256,7 +8256,7 @@ mocha.describe("Angular generator", function () {
 
           assert.strictEqual(getter.isMemorized(), true);
           assert.strictEqual(
-            getResult(getter.toString()),
+            getResult(getter.toString({members: [], isComponent:true})),
             getResult(`get name():{}{
                             if(this.__getterCache["name"]!==undefined){
                                 return this.__getterCache["name"]

--- a/packages/tests/unit-tests/inferno-generator.test.ts
+++ b/packages/tests/unit-tests/inferno-generator.test.ts
@@ -196,7 +196,7 @@ mocha.describe("Expressions", function () {
 
         assert.strictEqual(getter.isMemorized(), true);
         assert.strictEqual(
-          getResult(getter.toString()),
+          getResult(getter.toString({members: [], isComponent:true})),
           getResult(`get name():{}{
                           if(this.__getterCache["name"]!==undefined){
                               return this.__getterCache["name"]
@@ -212,13 +212,13 @@ mocha.describe("Expressions", function () {
         const getter = createGetAccessor(undefined,undefined,undefined,[createDecorator(Decorators.Provider)]);
         assert.strictEqual(getter.isMemorized(), true);
         assert.strictEqual(
-          getResult(getter.toString()),
+          getResult(getter.toString({members: [], isComponent:true})),
           getResult(`get name(): any {
                           if(this.__getterCache["name"]!==undefined){
                               return this.__getterCache["name"]
                           }
                   
-                          return this.__getterCache["name"]=(() => {
+                          return this.__getterCache["name"]=((): any => {
                               return result;
                           })();
                       }`)
@@ -316,7 +316,6 @@ mocha.describe("Expressions", function () {
                       name?: number[]
                   } = {}`)
         );
-        console.log(componentWillUpdate);
         assert.deepStrictEqual(
           componentWillUpdate.map(s => getResult(s)),
             [

--- a/packages/tests/unit-tests/test-cases/declarations/src/getter-with-complex-type.tsx
+++ b/packages/tests/unit-tests/test-cases/declarations/src/getter-with-complex-type.tsx
@@ -48,3 +48,10 @@ export default class Widget extends JSXComponent<Props>() {
     return [this.cons]
   }
 }
+
+class SomeClass {
+  i = 2;
+  get numberGetter(): number[] {
+    return [this.i, this.i];
+  }
+}

--- a/packages/tests/unit-tests/test-cases/expected/angular/context.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/context.tsx
@@ -67,7 +67,7 @@ export default class Widget extends Props {
     return (this.contextProviderProvider.value = this.__getterCache[
       "contextProvider"
     ] =
-      (() => {
+      ((): any => {
         return "provide";
       })());
   }

--- a/packages/tests/unit-tests/test-cases/expected/angular/getter-with-complex-type.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/getter-with-complex-type.tsx
@@ -47,7 +47,7 @@ export default class Widget extends Props {
       return this.__getterCache["provide"];
     }
     return (this.provideProvider.value = this.__getterCache["provide"] =
-      (() => {
+      ((): any => {
         return this.i;
       })());
   }
@@ -143,3 +143,10 @@ export default class Widget extends Props {
 })
 export class DxWidgetModule {}
 export { Widget as DxWidgetComponent };
+
+class SomeClass {
+  i: number = 2;
+  get numberGetter(): number[] {
+    return [this.i, this.i];
+  }
+}

--- a/packages/tests/unit-tests/test-cases/expected/inferno/context.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/context.tsx
@@ -55,7 +55,7 @@ export default class Widget extends BaseInfernoComponent<any> {
     if (this.__getterCache["contextProvider"] !== undefined) {
       return this.__getterCache["contextProvider"];
     }
-    return (this.__getterCache["contextProvider"] = (() => {
+    return (this.__getterCache["contextProvider"] = ((): any => {
       return "provide";
     })());
   }

--- a/packages/tests/unit-tests/test-cases/expected/inferno/getter-with-complex-type.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/getter-with-complex-type.tsx
@@ -60,7 +60,7 @@ export default class Widget extends InfernoWrapperComponent<any> {
     if (this.__getterCache["provide"] !== undefined) {
       return this.__getterCache["provide"];
     }
-    return (this.__getterCache["provide"] = (() => {
+    return (this.__getterCache["provide"] = ((): any => {
       return this.state.i;
     })());
   }
@@ -127,3 +127,10 @@ export default class Widget extends InfernoWrapperComponent<any> {
 }
 
 Widget.defaultProps = Props;
+
+class SomeClass {
+  i: number = 2;
+  get numberGetter(): number[] {
+    return [this.i, this.i];
+  }
+}


### PR DESCRIPTION
* removed side effect of caching base class getters in inferno and angular

* fixed tests

* add exact flag for generating cached getters