### PR TITLE
Fix named slot for angular. 

### DIFF
--- a/packages/angular-generator/src/expressions/decorator.ts
+++ b/packages/angular-generator/src/expressions/decorator.ts
@@ -10,6 +10,7 @@ import {
   Identifier,
   ObjectLiteral,
   Property,
+  SimpleExpression,
   StringLiteral,
   TemplateExpression,
 } from '@devextreme-generator/core';
@@ -184,7 +185,9 @@ function compileSlots(options?: toStringOptions): string[] {
     options?.members
       .filter((m) => m instanceof Property && m.isSlot)
       .map((slot) => {
-        const selector = slot.name.toString() === 'children' ? '' : `select="[${slot.name}]"`;
+        const cssSelector = slot.getDecoratorParameter<SimpleExpression>(Decorators.Slot, 'selector')?.expression
+        || `[data-${slot.name.toLocaleLowerCase()}]`;
+        const selector = slot.name.toString() === 'children' ? '' : `select="${cssSelector}"`;
         return `<ng-template #dx${slot.name}><ng-content ${selector}></ng-content></ng-template>`;
       }) || []
   );

--- a/packages/angular-generator/src/expressions/jsx/attribute.ts
+++ b/packages/angular-generator/src/expressions/jsx/attribute.ts
@@ -115,7 +115,7 @@ export class JsxAttribute extends BaseJsxAttribute {
   }
 
   compileBase(name: string, value: string) {
-    return `[${name}]="${value}"`;
+    return name.startsWith('data-') ? `${name.toLocaleLowerCase()}="${value}"` : `[${name}]="${value}"`;
   }
 
   isStringLiteralValue() {

--- a/packages/angular-generator/src/expressions/jsx/jsx-child-expression.ts
+++ b/packages/angular-generator/src/expressions/jsx/jsx-child-expression.ts
@@ -217,11 +217,13 @@ export class JsxChildExpression extends JsxExpression {
   }
 
   getSlot(stringValue: string, options?: toStringOptions) {
-    return options?.members
-      .filter((m) => m.isSlot)
-      .find(
-        (s) => (stringValue === s.getter(options.newComponentContext)),
-      ) as Property | undefined;
+    const possibleSlots = options?.members
+      .filter((m) => m.isSlot
+      && (stringValue.indexOf(m.getter(options.newComponentContext)) !== -1));
+    if (possibleSlots && possibleSlots.length > 1) {
+      throw new Error(`Slot name '${stringValue}' overlap for slot: ${possibleSlots.map((m) => m.name)}`);
+    }
+    return possibleSlots && possibleSlots[0] as Property | undefined;
   }
 
   addCallParameters(

--- a/packages/angular-generator/src/expressions/jsx/jsx-child-expression.ts
+++ b/packages/angular-generator/src/expressions/jsx/jsx-child-expression.ts
@@ -220,7 +220,7 @@ export class JsxChildExpression extends JsxExpression {
     return options?.members
       .filter((m) => m.isSlot)
       .find(
-        (s) => stringValue.indexOf(s.getter(options.newComponentContext)) !== -1,
+        (s) => (stringValue === s.getter(options.newComponentContext)),
       ) as Property | undefined;
   }
 

--- a/packages/angular-generator/src/expressions/jsx/jsx-child-expression.ts
+++ b/packages/angular-generator/src/expressions/jsx/jsx-child-expression.ts
@@ -220,7 +220,7 @@ export class JsxChildExpression extends JsxExpression {
     const possibleSlots = options?.members
       .filter((m) => m.isSlot
       && (stringValue.indexOf(m.getter(options.newComponentContext)) !== -1));
-    if (possibleSlots && possibleSlots.length > 1) {
+    if ((stringValue.indexOf('children') === -1) && possibleSlots && possibleSlots.length > 1) {
       throw new Error(`Slot name '${stringValue}' overlap for slot: ${possibleSlots.map((m) => m.name)}`);
     }
     return possibleSlots && possibleSlots[0] as Property | undefined;

--- a/packages/core-generator/src/expressions/class-members.ts
+++ b/packages/core-generator/src/expressions/class-members.ts
@@ -69,6 +69,12 @@ export class BaseClassMember extends Expression {
     return true;
   }
 
+  public getDecoratorParameter<E extends Expression>(decoratorType: Decorators,
+    paramName: string): E | null | undefined {
+    const decorator = this.decorators.find((d) => d.name === decoratorType);
+    return decorator?.getParameter(paramName) as E;
+  }
+
   get isInternalState() {
     return false;
   }
@@ -77,86 +83,85 @@ export class BaseClassMember extends Expression {
     return this.decorators.some((d) => d.name === name);
   }
 
-  get isEvent() {
+  get isEvent(): boolean {
     return this._hasDecorator(Decorators.Event);
   }
 
-  get isState() {
+  get isState(): boolean {
     return this._hasDecorator(Decorators.TwoWay);
   }
 
-  get isRef() {
+  get isRef(): boolean {
     return this._hasDecorator(Decorators.Ref);
   }
 
-  get isRefProp() {
+  get isRefProp(): boolean {
     return this._hasDecorator(Decorators.RefProp);
   }
 
-  get isNested() {
+  get isNested(): boolean {
     return this._hasDecorator(Decorators.Nested);
   }
 
-  get isNestedComp() {
+  get isNestedComp(): boolean {
     return this._hasDecorator(Decorators.NestedComp);
   }
 
-  get isSlot() {
+  get isSlot(): boolean {
     return (
       this._hasDecorator(Decorators.Slot)
       || this._hasDecorator(Decorators.ViewChild)
     );
   }
 
-  get isSvgSlot() {
-    const decorator = this.decorators.find((d) => d.name === Decorators.Slot);
-    return decorator?.getParameter('isSVG')?.toString() === 'true';
+  get isSvgSlot(): boolean {
+    return this.getDecoratorParameter(Decorators.Slot, 'isSVG')?.toString() === 'true';
   }
 
-  get isTemplate() {
+  get isTemplate(): boolean {
     return this._hasDecorator(Decorators.Template);
   }
 
-  get isApiMethod() {
+  get isApiMethod(): boolean {
     return this._hasDecorator(Decorators.Method);
   }
 
-  get isEffect() {
+  get isEffect(): boolean {
     return this._hasDecorator(Decorators.Effect);
   }
 
-  get isForwardRefProp() {
+  get isForwardRefProp(): boolean {
     return this._hasDecorator(Decorators.ForwardRefProp);
   }
 
-  get isForwardRef() {
+  get isForwardRef(): boolean {
     return this._hasDecorator(Decorators.ForwardRef);
   }
 
-  get isConsumer() {
+  get isConsumer(): boolean {
     return this._hasDecorator(Decorators.Consumer);
   }
 
-  get isProvider() {
+  get isProvider(): boolean {
     return this._hasDecorator(Decorators.Provider);
   }
 
-  get isApiRef() {
+  get isApiRef(): boolean {
     return this._hasDecorator(Decorators.ApiRef);
   }
 
-  get isMutable() {
+  get isMutable(): boolean {
     return this._hasDecorator(Decorators.Mutable);
   }
 
-  get context() {
+  get context(): Expression {
     const decorator = this.decorators.find(
       (d) => d.name === Decorators.Consumer || d.name === Decorators.Provider,
     ) as Decorator;
     return decorator.expression.arguments[0];
   }
 
-  get canBeDestructured() {
+  get canBeDestructured(): boolean {
     return this.name === this._name.toString();
   }
 
@@ -168,7 +173,7 @@ export class BaseClassMember extends Expression {
     return [this._name.toString()];
   }
 
-  get isPrivate() {
+  get isPrivate():boolean {
     return this.modifiers.indexOf(SyntaxKind.PrivateKeyword) !== -1;
   }
 }
@@ -226,16 +231,14 @@ export class Method extends BaseClassMember {
   }
 
   typeDeclaration() {
-    return `${this._name}${
-      this.questionToken
+    return `${this._name}${this.questionToken
     }:${this.compileTypeParameters()}(${this.parameters
       .map((p) => p.typeDeclaration())
       .join(',')})=>${this.type}`;
   }
 
   declaration(options?: toStringOptions) {
-    return `function ${this.name}${this.compileTypeParameters()}(${
-      this.parameters
+    return `function ${this.name}${this.compileTypeParameters()}(${this.parameters
     })${compileType(this.type.toString())}${this.body?.toString(options)}`;
   }
 
@@ -310,8 +313,7 @@ export class Method extends BaseClassMember {
   }
 
   toString(options?: toStringOptions): string {
-    return `${this.decorators.join(' ')}${this.compileModifiers()} ${
-      this.name
+    return `${this.decorators.join(' ')}${this.compileModifiers()} ${this.name
     }${this.compileTypeParameters()}(${this.parameters})${compileType(
       this.type.toString(),
     )}${this.compileBody(options)}`;
@@ -372,8 +374,8 @@ export class GetAccessor extends Method {
       const containMutableDep = depMembers
         .some((dep) => mutables?.includes(dep));
       return !containMutableDep
-      && (isComplexType(this.type, this.contextTypes, dependencies.length > 0)
-        || this.isProvider);
+        && (isComplexType(this.type, this.contextTypes, dependencies.length > 0)
+          || this.isProvider);
     }
     return false;
   }
@@ -469,10 +471,9 @@ export class Property extends BaseClassMember {
   toString(_options?: toStringOptions) {
     return `${this.modifiers.join(' ')} ${this.decorators
       .map((d) => d.toString())
-      .join(' ')} ${this.typeDeclaration()} ${
-      this.initializer && this.initializer.toString()
-        ? `= ${this.initializer.toString()}`
-        : ''
+      .join(' ')} ${this.typeDeclaration()} ${this.initializer && this.initializer.toString()
+      ? `= ${this.initializer.toString()}`
+      : ''
     }`;
   }
 
@@ -501,12 +502,11 @@ export class Constructor {
     public modifiers: string[] = [],
     public parameters: Parameter[],
     public body: Block | undefined,
-  ) {}
+  ) { }
 
   toString() {
     return `${this.decorators.join(' ')}
-      ${this.modifiers.join(' ')} constructor(${this.parameters})${
-  this.body || '{}'
+      ${this.modifiers.join(' ')} constructor(${this.parameters})${this.body || '{}'
 }
     `;
   }

--- a/packages/declarations/src/common.ts
+++ b/packages/declarations/src/common.ts
@@ -74,10 +74,10 @@ export function Component(arg: ComponentParameters) {
  * Class can contains only properties with decorators OneWay, TwoWay, Slot, Template.
  */
 export function ComponentBindings() {
-  return function ComponentBindings(_constructor: Function) {};
+  return function ComponentBindings(_constructor: Function) { };
 }
 
-const propertyDecorator = function (_target: any, _propertyKey: string) {};
+const propertyDecorator = function (_target: any, _propertyKey: string) { };
 
 /**
  * Property Decorator.
@@ -119,6 +119,10 @@ export const Template = () => propertyDecorator;
  */
 export const Slot = (_args?: {
   /**
+   * Specify CSS selector for ng-contnent. If selector is not specified the "[data-${propName.toLowercase()}]" is used.
+   */
+  selector?: string;
+  /**
    * Specify whether to pass content as svg
    */
   isSVG?: boolean;
@@ -144,7 +148,7 @@ export const InternalState = () => propertyDecorator;
  */
 export const Mutable = () => propertyDecorator;
 
-class Context {}
+class Context { }
 
 export const Provider = (_Context: Context) => propertyDecorator;
 
@@ -182,7 +186,7 @@ interface JSXComponentBase<_P> {
   state(): any;
   isReactComponent: any;
 }
-class JSXComponentBase<_P> {}
+class JSXComponentBase<_P> { }
 /**
  * A function that returns base class for any Component.
  * Pass ComponentBindings as an argument
@@ -193,7 +197,7 @@ export function JSXComponent<
   keyof PropsType,
   keyof PropsType
   >,
->(Props?: { new (): PropsType & { ref?: React.Component<PropsType> } }) {
+  >(Props?: { new(): PropsType & { ref?: React.Component<PropsType> } }) {
   type DefaultPropsType = Omit<PropsType, RequiredProps> & {
     [name: string]: any;
   };
@@ -229,10 +233,10 @@ export type JSXTemplate<
   keyof PropsType,
   keyof PropsType
   >,
-> = React.JSXElementConstructor<
-Partial<Omit<PropsType, RequiredProps>> &
-Required<Pick<PropsType, RequiredProps>>
->;
+  > = React.JSXElementConstructor<
+  Partial<Omit<PropsType, RequiredProps>> &
+  Required<Pick<PropsType, RequiredProps>>
+  >;
 
 /**
  * Type for styles.

--- a/packages/tests/unit-tests/test-cases/declarations/src/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/declarations/src/slots.tsx
@@ -8,7 +8,7 @@ import {
 function view(viewModel: SlotsWidget) {
   return (
     <div>
-      <div>{viewModel.props.namedSlotWithSelector}</div>
+      <div>{viewModel.props.selectorNamedSlot}</div>
       <div>{viewModel.props.namedSlot}</div>
       <div>{viewModel.props.children}</div>
     </div>
@@ -18,7 +18,7 @@ function view(viewModel: SlotsWidget) {
 @ComponentBindings()
 class SlotsWidgetProps {
   @Slot() namedSlot?: JSX.Element;
-  @Slot({ selector: '.namedSlot' }) namedSlotWithSelector?: JSX.Element;
+  @Slot({ selector: '.namedSlot' }) selectorNamedSlot?: JSX.Element;
   @Slot() children?: JSX.Element;
 }
 @Component({

--- a/packages/tests/unit-tests/test-cases/declarations/src/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/declarations/src/slots.tsx
@@ -5,9 +5,10 @@ import {
   JSXComponent,
 } from "@devextreme-generator/declarations";
 
-function view(viewModel: Widget) {
+function view(viewModel: SlotsWidget) {
   return (
     <div>
+      <div>{viewModel.props.namedSlotWithSelector}</div>
       <div>{viewModel.props.namedSlot}</div>
       <div>{viewModel.props.children}</div>
     </div>
@@ -15,11 +16,12 @@ function view(viewModel: Widget) {
 }
 
 @ComponentBindings()
-class WidgetInput {
+class SlotsWidgetProps {
   @Slot() namedSlot?: JSX.Element;
+  @Slot({ selector: '.namedSlot' }) namedSlotWithSelector?: JSX.Element;
   @Slot() children?: JSX.Element;
 }
 @Component({
   view: view,
 })
-export default class Widget extends JSXComponent(WidgetInput) {}
+export default class SlotsWidget extends JSXComponent(SlotsWidgetProps) { }

--- a/packages/tests/unit-tests/test-cases/expected/angular/nested-props-and-component.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/nested-props-and-component.tsx
@@ -91,7 +91,7 @@ class DxUndefWidgetNestedProp extends FakeNested {}
   template: `<ng-template #widgetTemplate
     ><div></div
     ><ng-template #dxslotProp
-      ><ng-content select="[slotProp]"></ng-content></ng-template
+      ><ng-content select="[data-slotprop]"></ng-content></ng-template
   ></ng-template>`,
 })
 export default class UndefWidget extends WidgetProps {

--- a/packages/tests/unit-tests/test-cases/expected/angular/slot-pass-from-rest.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/slot-pass-from-rest.tsx
@@ -1,4 +1,4 @@
-import Widget, { DxWidgetModule } from "./slots";
+import Widget, { DxSlotsWidgetModule } from "./slots";
 import { Injectable, Input, ViewChild, ElementRef } from "@angular/core";
 @Injectable()
 class WidgetInput {
@@ -33,11 +33,11 @@ import {
   inputs: ["p"],
   template: `<ng-template #widgetTemplate
     ><div
-      ><dx-widget #widget1 style="display: contents"
+      ><dx-slots-widget #widget1 style="display: contents"
         ><div #slotChildren style="display: contents"
           ><ng-container
             [ngTemplateOutlet]="dxchildren"
-          ></ng-container></div></dx-widget
+          ></ng-container></div></dx-slots-widget
       ><ng-content
         *ngTemplateOutlet="widget1?.widgetTemplate"
       ></ng-content></div
@@ -94,7 +94,7 @@ export default class SlotPass extends WidgetInput {
 }
 @NgModule({
   declarations: [SlotPass],
-  imports: [DxWidgetModule, CommonModule],
+  imports: [DxSlotsWidgetModule, CommonModule],
   entryComponents: [Widget],
   exports: [SlotPass],
 })

--- a/packages/tests/unit-tests/test-cases/expected/angular/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/slots.tsx
@@ -7,11 +7,10 @@ class SlotsWidgetProps {
     const childNodes = this.__slotNamedSlot?.nativeElement?.childNodes;
     return childNodes && childNodes.length > 2;
   }
-  __slotNamedSlotWithSelector?: ElementRef<HTMLDivElement>;
+  __slotSelectorNamedSlot?: ElementRef<HTMLDivElement>;
 
-  get namedSlotWithSelector() {
-    const childNodes =
-      this.__slotNamedSlotWithSelector?.nativeElement?.childNodes;
+  get selectorNamedSlot() {
+    const childNodes = this.__slotSelectorNamedSlot?.nativeElement?.childNodes;
     return childNodes && childNodes.length > 2;
   }
   __slotChildren?: ElementRef<HTMLDivElement>;
@@ -40,9 +39,9 @@ import { CommonModule } from "@angular/common";
   template: `<ng-template #widgetTemplate
     ><div
       ><div
-        ><div #slotNamedSlotWithSelector style="display: contents"
+        ><div #slotSelectorNamedSlot style="display: contents"
           ><ng-container
-            [ngTemplateOutlet]="dxnamedSlotWithSelector"
+            [ngTemplateOutlet]="dxselectorNamedSlot"
           ></ng-container></div></div
       ><div
         ><div #slotNamedSlot style="display: contents"
@@ -56,7 +55,7 @@ import { CommonModule } from "@angular/common";
           ></ng-container></div></div></div
     ><ng-template #dxnamedSlot
       ><ng-content select="[data-namedslot]"></ng-content></ng-template
-    ><ng-template #dxnamedSlotWithSelector
+    ><ng-template #dxselectorNamedSlot
       ><ng-content select=".namedSlot"></ng-content></ng-template
     ><ng-template #dxchildren><ng-content></ng-content></ng-template
   ></ng-template>`,
@@ -91,12 +90,12 @@ export default class SlotsWidget extends SlotsWidgetProps {
       this._detectChanges();
     }
   }
-  @ViewChild("slotNamedSlotWithSelector") set slotNamedSlotWithSelector(
+  @ViewChild("slotSelectorNamedSlot") set slotSelectorNamedSlot(
     slot: ElementRef<HTMLDivElement>
   ) {
-    const oldValue = this.namedSlotWithSelector;
-    this.__slotNamedSlotWithSelector = slot;
-    const newValue = this.namedSlotWithSelector;
+    const oldValue = this.selectorNamedSlot;
+    this.__slotSelectorNamedSlot = slot;
+    const newValue = this.selectorNamedSlot;
     if (!!oldValue !== !!newValue) {
       this._detectChanges();
     }

--- a/packages/tests/unit-tests/test-cases/expected/angular/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/slots.tsx
@@ -1,10 +1,17 @@
 import { Injectable, ViewChild, ElementRef } from "@angular/core";
 @Injectable()
-class WidgetInput {
+class SlotsWidgetProps {
   __slotNamedSlot?: ElementRef<HTMLDivElement>;
 
   get namedSlot() {
     const childNodes = this.__slotNamedSlot?.nativeElement?.childNodes;
+    return childNodes && childNodes.length > 2;
+  }
+  __slotNamedSlotWithSelector?: ElementRef<HTMLDivElement>;
+
+  get namedSlotWithSelector() {
+    const childNodes =
+      this.__slotNamedSlotWithSelector?.nativeElement?.childNodes;
     return childNodes && childNodes.length > 2;
   }
   __slotChildren?: ElementRef<HTMLDivElement>;
@@ -28,10 +35,15 @@ import {
 import { CommonModule } from "@angular/common";
 
 @Component({
-  selector: "dx-widget",
+  selector: "dx-slots-widget",
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-template #widgetTemplate
     ><div
+      ><div
+        ><div #slotNamedSlotWithSelector style="display: contents"
+          ><ng-container
+            [ngTemplateOutlet]="dxnamedSlotWithSelector"
+          ></ng-container></div></div
       ><div
         ><div #slotNamedSlot style="display: contents"
           ><ng-container
@@ -43,11 +55,13 @@ import { CommonModule } from "@angular/common";
             [ngTemplateOutlet]="dxchildren"
           ></ng-container></div></div></div
     ><ng-template #dxnamedSlot
-      ><ng-content select="[namedSlot]"></ng-content></ng-template
+      ><ng-content select="[data-namedslot]"></ng-content></ng-template
+    ><ng-template #dxnamedSlotWithSelector
+      ><ng-content select=".namedSlot"></ng-content></ng-template
     ><ng-template #dxchildren><ng-content></ng-content></ng-template
   ></ng-template>`,
 })
-export default class Widget extends WidgetInput {
+export default class SlotsWidget extends SlotsWidgetProps {
   get __restAttributes(): any {
     return {};
   }
@@ -77,6 +91,16 @@ export default class Widget extends WidgetInput {
       this._detectChanges();
     }
   }
+  @ViewChild("slotNamedSlotWithSelector") set slotNamedSlotWithSelector(
+    slot: ElementRef<HTMLDivElement>
+  ) {
+    const oldValue = this.namedSlotWithSelector;
+    this.__slotNamedSlotWithSelector = slot;
+    const newValue = this.namedSlotWithSelector;
+    if (!!oldValue !== !!newValue) {
+      this._detectChanges();
+    }
+  }
   @ViewChild("slotChildren") set slotChildren(
     slot: ElementRef<HTMLDivElement>
   ) {
@@ -89,10 +113,10 @@ export default class Widget extends WidgetInput {
   }
 }
 @NgModule({
-  declarations: [Widget],
+  declarations: [SlotsWidget],
   imports: [CommonModule],
 
-  exports: [Widget],
+  exports: [SlotsWidget],
 })
-export class DxWidgetModule {}
-export { Widget as DxWidgetComponent };
+export class DxSlotsWidgetModule {}
+export { SlotsWidget as DxSlotsWidgetComponent };

--- a/packages/tests/unit-tests/test-cases/expected/preact/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/preact/slots.tsx
@@ -1,6 +1,8 @@
-function view(viewModel: Widget) {
+function view(viewModel: SlotsWidget) {
   return (
     <div>
+      <div>{viewModel.props.namedSlotWithSelector}</div>
+
       <div>{viewModel.props.namedSlot}</div>
 
       <div>{viewModel.props.children}</div>
@@ -8,11 +10,12 @@ function view(viewModel: Widget) {
   );
 }
 
-export declare type WidgetInputType = {
+export declare type SlotsWidgetPropsType = {
   namedSlot?: any;
+  namedSlotWithSelector?: any;
   children?: any;
 };
-const WidgetInput: WidgetInputType = {};
+const SlotsWidgetProps: SlotsWidgetPropsType = {};
 import * as Preact from "preact";
 import { useCallback } from "preact/hooks";
 
@@ -22,15 +25,18 @@ declare type RestProps = {
   key?: any;
   ref?: any;
 };
-interface Widget {
-  props: typeof WidgetInput & RestProps;
+interface SlotsWidget {
+  props: typeof SlotsWidgetProps & RestProps;
   restAttributes: RestProps;
 }
 
-export default function Widget(props: typeof WidgetInput & RestProps) {
+export default function SlotsWidget(
+  props: typeof SlotsWidgetProps & RestProps
+) {
   const __restAttributes = useCallback(
     function __restAttributes(): RestProps {
-      const { children, namedSlot, ...restProps } = props;
+      const { children, namedSlot, namedSlotWithSelector, ...restProps } =
+        props;
       return restProps;
     },
     [props]
@@ -39,4 +45,4 @@ export default function Widget(props: typeof WidgetInput & RestProps) {
   return view({ props: { ...props }, restAttributes: __restAttributes() });
 }
 
-Widget.defaultProps = WidgetInput;
+SlotsWidget.defaultProps = SlotsWidgetProps;

--- a/packages/tests/unit-tests/test-cases/expected/preact/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/preact/slots.tsx
@@ -1,7 +1,7 @@
 function view(viewModel: SlotsWidget) {
   return (
     <div>
-      <div>{viewModel.props.namedSlotWithSelector}</div>
+      <div>{viewModel.props.selectorNamedSlot}</div>
 
       <div>{viewModel.props.namedSlot}</div>
 
@@ -12,7 +12,7 @@ function view(viewModel: SlotsWidget) {
 
 export declare type SlotsWidgetPropsType = {
   namedSlot?: any;
-  namedSlotWithSelector?: any;
+  selectorNamedSlot?: any;
   children?: any;
 };
 const SlotsWidgetProps: SlotsWidgetPropsType = {};
@@ -35,8 +35,7 @@ export default function SlotsWidget(
 ) {
   const __restAttributes = useCallback(
     function __restAttributes(): RestProps {
-      const { children, namedSlot, namedSlotWithSelector, ...restProps } =
-        props;
+      const { children, namedSlot, selectorNamedSlot, ...restProps } = props;
       return restProps;
     },
     [props]

--- a/packages/tests/unit-tests/test-cases/expected/react/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/slots.tsx
@@ -1,7 +1,7 @@
 function view(viewModel: SlotsWidget) {
   return (
     <div>
-      <div>{viewModel.props.namedSlotWithSelector}</div>
+      <div>{viewModel.props.selectorNamedSlot}</div>
 
       <div>{viewModel.props.namedSlot}</div>
 
@@ -12,7 +12,7 @@ function view(viewModel: SlotsWidget) {
 
 export declare type SlotsWidgetPropsType = {
   namedSlot?: React.ReactNode;
-  namedSlotWithSelector?: React.ReactNode;
+  selectorNamedSlot?: React.ReactNode;
   children?: React.ReactNode;
 };
 const SlotsWidgetProps: SlotsWidgetPropsType = {};
@@ -35,8 +35,7 @@ export default function SlotsWidget(
 ) {
   const __restAttributes = useCallback(
     function __restAttributes(): RestProps {
-      const { children, namedSlot, namedSlotWithSelector, ...restProps } =
-        props;
+      const { children, namedSlot, selectorNamedSlot, ...restProps } = props;
       return restProps;
     },
     [props]

--- a/packages/tests/unit-tests/test-cases/expected/react/slots.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/slots.tsx
@@ -1,6 +1,8 @@
-function view(viewModel: Widget) {
+function view(viewModel: SlotsWidget) {
   return (
     <div>
+      <div>{viewModel.props.namedSlotWithSelector}</div>
+
       <div>{viewModel.props.namedSlot}</div>
 
       <div>{viewModel.props.children}</div>
@@ -8,11 +10,12 @@ function view(viewModel: Widget) {
   );
 }
 
-export declare type WidgetInputType = {
+export declare type SlotsWidgetPropsType = {
   namedSlot?: React.ReactNode;
+  namedSlotWithSelector?: React.ReactNode;
   children?: React.ReactNode;
 };
-const WidgetInput: WidgetInputType = {};
+const SlotsWidgetProps: SlotsWidgetPropsType = {};
 import * as React from "react";
 import { useCallback } from "react";
 
@@ -22,15 +25,18 @@ declare type RestProps = {
   key?: any;
   ref?: any;
 };
-interface Widget {
-  props: typeof WidgetInput & RestProps;
+interface SlotsWidget {
+  props: typeof SlotsWidgetProps & RestProps;
   restAttributes: RestProps;
 }
 
-export default function Widget(props: typeof WidgetInput & RestProps) {
+export default function SlotsWidget(
+  props: typeof SlotsWidgetProps & RestProps
+) {
   const __restAttributes = useCallback(
     function __restAttributes(): RestProps {
-      const { children, namedSlot, ...restProps } = props;
+      const { children, namedSlot, namedSlotWithSelector, ...restProps } =
+        props;
       return restProps;
     },
     [props]
@@ -39,4 +45,4 @@ export default function Widget(props: typeof WidgetInput & RestProps) {
   return view({ props: { ...props }, restAttributes: __restAttributes() });
 }
 
-Widget.defaultProps = WidgetInput;
+SlotsWidget.defaultProps = SlotsWidgetProps;

--- a/packages/tests/unit-tests/test-cases/expected/vue/slots.vue
+++ b/packages/tests/unit-tests/test-cases/expected/vue/slots.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    ><div><slot name="namedSlotWithSelector"></slot></div
+    ><div><slot name="selectorNamedSlot"></slot></div
     ><div><slot name="namedSlot"></slot></div><div><slot></slot></div
   ></div>
 </template>
@@ -16,7 +16,7 @@ export const DxSlotsWidget = {
     props() {
       return {
         namedSlot: this.$slots.namedSlot,
-        namedSlotWithSelector: this.$slots.namedSlotWithSelector,
+        selectorNamedSlot: this.$slots.selectorNamedSlot,
         children: this.$slots.default,
       };
     },

--- a/packages/tests/unit-tests/test-cases/expected/vue/slots.vue
+++ b/packages/tests/unit-tests/test-cases/expected/vue/slots.vue
@@ -1,13 +1,14 @@
 <template>
   <div
+    ><div><slot name="namedSlotWithSelector"></slot></div
     ><div><slot name="namedSlot"></slot></div><div><slot></slot></div
   ></div>
 </template>
 <script>
-const WidgetInput = {};
-export const DxWidget = {
-  name: "Widget",
-  props: WidgetInput,
+const SlotsWidgetProps = {};
+export const DxSlotsWidget = {
+  name: "SlotsWidget",
+  props: SlotsWidgetProps,
   computed: {
     __restAttributes() {
       return {};
@@ -15,10 +16,11 @@ export const DxWidget = {
     props() {
       return {
         namedSlot: this.$slots.namedSlot,
+        namedSlotWithSelector: this.$slots.namedSlotWithSelector,
         children: this.$slots.default,
       };
     },
   },
 };
-export default DxWidget;
+export default DxSlotsWidget;
 </script>


### PR DESCRIPTION
Add new selector into parameter into the Slot decorator.
This selector put into the <ng-content selector>
If named slot doesn't scpecify selector the '[data-${slotPropertyName.toLowercase()}]' is used
"data-*" pattern used for the safe declaring attribute in declaration scenario.