### PR TITLE
React: Remove getter for complex value default's.

### DIFF
--- a/packages/react-generator/src/expressions/class-members/property.ts
+++ b/packages/react-generator/src/expressions/class-members/property.ts
@@ -11,6 +11,9 @@ import {
   SyntaxKind,
   toStringOptions,
   TypeExpression,
+  ObjectLiteral,
+  ArrayLiteral,
+  New,
 } from '@devextreme-generator/core';
 
 import {
@@ -53,12 +56,22 @@ export function compileJSXTemplateType(
 }
 
 export class Property extends BaseProperty {
+  get hasObjectLiteralInitializer(): boolean {
+    const { initializer } = this;
+    return initializer instanceof ObjectLiteral
+      || initializer instanceof ArrayLiteral
+      || initializer instanceof New;
+  }
+
   defaultProps(options?: toStringOptions) {
     const { initializer } = this;
     const isSimpleExpression = initializer instanceof SimpleExpression;
     const isFunction = initializer instanceof BaseFunction;
     const isComplexExpression = !(isSimpleExpression || isFunction);
     if (isComplexExpression || options?.fromType) {
+      if (this.hasObjectLiteralInitializer) {
+        return `${this.name}: Object.freeze(${initializer?.toString(options)}) as any`;
+      }
       return `get ${this.name}() { return ${initializer?.toString(options)} }`;
     }
     return this.defaultDeclaration(options);

--- a/packages/tests/unit-tests/test-cases/declarations/src/props.tsx
+++ b/packages/tests/unit-tests/test-cases/declarations/src/props.tsx
@@ -26,7 +26,7 @@ export class WidgetInput {
   @OneWay() height = 10;
   @OneWay() export: object = {};
   @OneWay() array = ["1"];
-
+  @OneWay() currentDate = new Date();
   @OneWay() expressionDefault: string = device === "ios" ? "yes" : "no";
   @OneWay() expressionDefault1: boolean = !device;
   @OneWay() expressionDefault2: boolean | string = isDevice() || "test";

--- a/packages/tests/unit-tests/test-cases/expected/angular/props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/props.tsx
@@ -12,6 +12,7 @@ export class WidgetInput {
   @Input() height: number = 10;
   @Input() export: object = {};
   @Input() array: any = ["1"];
+  @Input() currentDate: any = new Date();
   @Input() expressionDefault: string = device === "ios" ? "yes" : "no";
   @Input() expressionDefault1: boolean = !device;
   @Input() expressionDefault2: boolean | string = isDevice() || "test";
@@ -45,6 +46,7 @@ import {
     "height",
     "export",
     "array",
+    "currentDate",
     "expressionDefault",
     "expressionDefault1",
     "expressionDefault2",
@@ -71,6 +73,7 @@ export default class Widget extends WidgetInput {
       height: this.height,
       export: this.export,
       array: this.array,
+      currentDate: this.currentDate,
       expressionDefault: this.expressionDefault,
       expressionDefault1: this.expressionDefault1,
       expressionDefault2: this.expressionDefault2,
@@ -116,6 +119,7 @@ export default class Widget extends WidgetInput {
       "height",
       "export",
       "array",
+      "currentDate",
       "expressionDefault",
       "expressionDefault1",
       "expressionDefault2",
@@ -129,6 +133,7 @@ export default class Widget extends WidgetInput {
     };
     this._stringValueChange = (e: any) => {
       this.stringValueChange.emit(e);
+
       this._detectChanges();
     };
   }

--- a/packages/tests/unit-tests/test-cases/expected/inferno/component-bindings-only.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/component-bindings-only.tsx
@@ -7,11 +7,7 @@ export declare type WidgetPropsType = {
 };
 const WidgetProps: WidgetPropsType = {
   height: 10,
-  get data() {
-    return { value: "" };
-  },
-  get info() {
-    return { index: 0 };
-  },
+  data: Object.freeze({ value: "" }) as any,
+  info: Object.freeze({ index: 0 }) as any,
 };
 export default WidgetProps;

--- a/packages/tests/unit-tests/test-cases/expected/inferno/component-input-defaults.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/component-input-defaults.tsx
@@ -25,9 +25,7 @@ export const BaseProps: BasePropsType = {
   get width() {
     return isMaterial() ? 20 : 10;
   },
-  get baseNested() {
-    return { text: "3" };
-  },
+  baseNested: Object.freeze({ text: "3" }) as any,
 };
 export declare type TextsPropsType = {
   text?: string;
@@ -60,15 +58,9 @@ export const WidgetProps: WidgetPropsType = Object.create(
       get text() {
         return format("text");
       },
-      get texts1() {
-        return { text: format("text") };
-      },
-      get texts2() {
-        return { text: format("text") };
-      },
-      get texts3() {
-        return TextsProps;
-      },
+      texts1: Object.freeze({ text: format("text") }) as any,
+      texts2: Object.freeze({ text: format("text") }) as any,
+      texts3: Object.freeze(TextsProps) as any,
       template: () => <div></div>,
     })
   )

--- a/packages/tests/unit-tests/test-cases/expected/inferno/getters-is-memorized.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/getters-is-memorized.tsx
@@ -19,9 +19,7 @@ export declare type WidgetPropsType = {
 const WidgetProps: WidgetPropsType = {
   someProp: "",
   type: "",
-  get defaultCurrentDate() {
-    return new Date();
-  },
+  defaultCurrentDate: Object.freeze(new Date()) as any,
   currentDateChange: () => {},
 } as any as WidgetPropsType;
 interface internalInterface {

--- a/packages/tests/unit-tests/test-cases/expected/inferno/nested-pick.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/nested-pick.tsx
@@ -8,9 +8,7 @@ export declare type BasePropsType = {
   nestedProp?: typeof NestedProps;
 };
 export const BaseProps: BasePropsType = {
-  get nestedProp() {
-    return {};
-  },
+  nestedProp: Object.freeze({}) as any,
 };
 export declare type SomePropsType = {
   nestedProp?: typeof NestedProps;

--- a/packages/tests/unit-tests/test-cases/expected/inferno/nested-props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/nested-props.tsx
@@ -34,9 +34,7 @@ export declare type WidgetPropsType = {
   editing: typeof EditingProps;
 };
 export const WidgetProps: WidgetPropsType = {
-  get editing() {
-    return EditingProps;
-  },
+  editing: Object.freeze(EditingProps) as any,
 };
 export declare type PickedPropsType = {
   columns?: Array<typeof GridColumnProps | string>;

--- a/packages/tests/unit-tests/test-cases/expected/inferno/props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/inferno/props.tsx
@@ -24,6 +24,7 @@ export declare type WidgetInputType = {
   height: number;
   export: object;
   array: any;
+  currentDate: any;
   expressionDefault: string;
   expressionDefault1: boolean;
   expressionDefault2: boolean | string;
@@ -36,12 +37,9 @@ export declare type WidgetInputType = {
 };
 export const WidgetInput: WidgetInputType = {
   height: 10,
-  get export() {
-    return {};
-  },
-  get array() {
-    return ["1"];
-  },
+  export: Object.freeze({}) as any,
+  array: Object.freeze(["1"]) as any,
+  currentDate: Object.freeze(new Date()) as any,
   get expressionDefault() {
     return device === "ios" ? "yes" : "no";
   },
@@ -100,6 +98,7 @@ export default class Widget extends BaseInfernoComponent<any> {
   get restAttributes(): RestProps {
     const {
       array,
+      currentDate,
       defaultStringValue,
       export: exportProp,
       expressionDefault,

--- a/packages/tests/unit-tests/test-cases/expected/preact/nested-props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/preact/nested-props.tsx
@@ -34,9 +34,7 @@ export declare type WidgetPropsType = {
   editing: typeof EditingProps;
 };
 export const WidgetProps: WidgetPropsType = {
-  get editing() {
-    return EditingProps;
-  },
+  editing: Object.freeze(EditingProps) as any,
 };
 export declare type PickedPropsType = {
   columns?: Array<typeof GridColumnProps | string>;

--- a/packages/tests/unit-tests/test-cases/expected/preact/props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/preact/props.tsx
@@ -18,6 +18,7 @@ export declare type WidgetInputType = {
   height: number;
   export: object;
   array: any;
+  currentDate: any;
   expressionDefault: string;
   expressionDefault1: boolean;
   expressionDefault2: boolean | string;
@@ -30,12 +31,9 @@ export declare type WidgetInputType = {
 };
 export const WidgetInput: WidgetInputType = {
   height: 10,
-  get export() {
-    return {};
-  },
-  get array() {
-    return ["1"];
-  },
+  export: Object.freeze({}) as any,
+  array: Object.freeze(["1"]) as any,
+  currentDate: Object.freeze(new Date()) as any,
   get expressionDefault() {
     return device === "ios" ? "yes" : "no";
   },
@@ -102,6 +100,7 @@ export default function Widget(props: typeof WidgetInput & RestProps) {
     function __restAttributes(): RestProps {
       const {
         array,
+        currentDate,
         defaultStringValue,
         export: exportProp,
         expressionDefault,

--- a/packages/tests/unit-tests/test-cases/expected/react/component-bindings-only.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/component-bindings-only.tsx
@@ -7,11 +7,7 @@ export declare type WidgetPropsType = {
 };
 const WidgetProps: WidgetPropsType = {
   height: 10,
-  get data() {
-    return { value: "" };
-  },
-  get info() {
-    return { index: 0 };
-  },
+  data: Object.freeze({ value: "" }) as any,
+  info: Object.freeze({ index: 0 }) as any,
 };
 export default WidgetProps;

--- a/packages/tests/unit-tests/test-cases/expected/react/component-input-defaults.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/component-input-defaults.tsx
@@ -21,9 +21,7 @@ export const BaseProps: BasePropsType = {
   get width() {
     return isMaterial() ? 20 : 10;
   },
-  get __defaultNestedValues() {
-    return { baseNested: { text: "3" } };
-  },
+  __defaultNestedValues: Object.freeze({ baseNested: { text: "3" } }) as any,
 };
 export declare type TextsPropsType = {
   text?: string;
@@ -59,17 +57,13 @@ export const WidgetProps: WidgetPropsType = Object.create(
       get text() {
         return format("text");
       },
-      get texts1() {
-        return { text: format("text") };
-      },
+      texts1: Object.freeze({ text: format("text") }) as any,
       template: () => <div></div>,
-      get __defaultNestedValues() {
-        return {
-          texts2: { text: format("text") },
-          texts3: TextsProps,
-          baseNested: BaseProps?.__defaultNestedValues.baseNested,
-        };
-      },
+      __defaultNestedValues: Object.freeze({
+        texts2: { text: format("text") },
+        texts3: TextsProps,
+        baseNested: BaseProps?.__defaultNestedValues.baseNested,
+      }) as any,
     })
   )
 );
@@ -96,13 +90,11 @@ const WidgetPropsType: WidgetPropsTypeType = {
   height: WidgetProps.height,
   width: WidgetProps.width,
   expressionDefault: ExpressionProps.expressionDefault,
-  get __defaultNestedValues() {
-    return {
-      texts2: WidgetProps.texts2,
-      texts3: WidgetProps.texts3,
-      baseNested: WidgetProps.baseNested,
-    };
-  },
+  __defaultNestedValues: Object.freeze({
+    texts2: WidgetProps.texts2,
+    texts3: WidgetProps.texts3,
+    baseNested: WidgetProps.baseNested,
+  }) as any,
 };
 import { __collectChildren, equalByValue } from "@devextreme/runtime/react";
 import * as React from "react";

--- a/packages/tests/unit-tests/test-cases/expected/react/getters-is-memorized.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/getters-is-memorized.tsx
@@ -13,9 +13,7 @@ export declare type WidgetPropsType = {
 const WidgetProps: WidgetPropsType = {
   someProp: "",
   type: "",
-  get defaultCurrentDate() {
-    return new Date();
-  },
+  defaultCurrentDate: Object.freeze(new Date()) as any,
   currentDateChange: () => {},
 } as any as WidgetPropsType;
 interface internalInterface {

--- a/packages/tests/unit-tests/test-cases/expected/react/nested-default-props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/nested-default-props.tsx
@@ -10,9 +10,7 @@ export declare type GridRowType = {
   children?: React.ReactNode;
 };
 export const GridRow: GridRowType = {
-  get __defaultNestedValues() {
-    return { cells: [GridCell] };
-  },
+  __defaultNestedValues: Object.freeze({ cells: [GridCell] }) as any,
 };
 export declare type WithNestedInputType = {
   rows?: typeof GridRow[];
@@ -20,13 +18,11 @@ export declare type WithNestedInputType = {
   children?: React.ReactNode;
 };
 export const WithNestedInput: WithNestedInputType = {
-  get __defaultNestedValues() {
-    return {
-      rows: [
-        GridRow.__defaultNestedValues ? GridRow.__defaultNestedValues : GridRow,
-      ],
-    };
-  },
+  __defaultNestedValues: Object.freeze({
+    rows: [
+      GridRow.__defaultNestedValues ? GridRow.__defaultNestedValues : GridRow,
+    ],
+  }) as any,
 };
 export declare type EmptyClassType = {};
 export const EmptyClass: EmptyClassType = {};
@@ -36,7 +32,5 @@ export declare type FakeNestedType = {
   children?: React.ReactNode;
 };
 export const FakeNested: FakeNestedType = {
-  get __defaultNestedValues() {
-    return { value: [EmptyClass] };
-  },
+  __defaultNestedValues: Object.freeze({ value: [EmptyClass] }) as any,
 };

--- a/packages/tests/unit-tests/test-cases/expected/react/nested-inherited.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/nested-inherited.tsx
@@ -12,9 +12,7 @@ export declare type WidgetPropsType = {
 };
 export const WidgetProps: WidgetPropsType = {
   baseProp: 0,
-  get __defaultNestedValues() {
-    return { someProp: FakeNested };
-  },
+  __defaultNestedValues: Object.freeze({ someProp: FakeNested }) as any,
 };
 export declare type TooltipPropsType = {
   tooltipValue: number;
@@ -24,15 +22,13 @@ export declare type TooltipPropsType = {
 };
 export const TooltipProps: TooltipPropsType = {
   tooltipValue: 0,
-  get __defaultNestedValues() {
-    return {
-      tooltipNested: [
-        WidgetProps.__defaultNestedValues
-          ? WidgetProps.__defaultNestedValues
-          : WidgetProps,
-      ],
-    };
-  },
+  __defaultNestedValues: Object.freeze({
+    tooltipNested: [
+      WidgetProps.__defaultNestedValues
+        ? WidgetProps.__defaultNestedValues
+        : WidgetProps,
+    ],
+  }) as any,
 };
 export declare type BulletPropsType = typeof WidgetProps & {
   value: number;
@@ -45,14 +41,12 @@ export const BulletProps: BulletPropsType = Object.create(
     Object.getOwnPropertyDescriptors(WidgetProps),
     Object.getOwnPropertyDescriptors({
       value: 0,
-      get __defaultNestedValues() {
-        return {
-          tooltip: TooltipProps.__defaultNestedValues
-            ? TooltipProps.__defaultNestedValues
-            : TooltipProps,
-          someProp: WidgetProps?.__defaultNestedValues.someProp,
-        };
-      },
+      __defaultNestedValues: Object.freeze({
+        tooltip: TooltipProps.__defaultNestedValues
+          ? TooltipProps.__defaultNestedValues
+          : TooltipProps,
+        someProp: WidgetProps?.__defaultNestedValues.someProp,
+      }) as any,
     })
   )
 );
@@ -65,13 +59,11 @@ export const BulletProps2: BulletProps2Type = Object.create(
   Object.assign(
     Object.getOwnPropertyDescriptors(BulletProps),
     Object.getOwnPropertyDescriptors({
-      get __defaultNestedValues() {
-        return {
-          fakeNestedArr: [FakeNested],
-          tooltip: BulletProps?.__defaultNestedValues.tooltip,
-          someProp: BulletProps?.__defaultNestedValues.someProp,
-        };
-      },
+      __defaultNestedValues: Object.freeze({
+        fakeNestedArr: [FakeNested],
+        tooltip: BulletProps?.__defaultNestedValues.tooltip,
+        someProp: BulletProps?.__defaultNestedValues.someProp,
+      }) as any,
     })
   )
 );
@@ -84,14 +76,12 @@ export const BulletProps3: BulletProps3Type = Object.create(
   Object.assign(
     Object.getOwnPropertyDescriptors(BulletProps2),
     Object.getOwnPropertyDescriptors({
-      get __defaultNestedValues() {
-        return {
-          fakeNestedArr2: [FakeNested],
-          fakeNestedArr: BulletProps2?.__defaultNestedValues.fakeNestedArr,
-          tooltip: BulletProps2?.__defaultNestedValues.tooltip,
-          someProp: BulletProps2?.__defaultNestedValues.someProp,
-        };
-      },
+      __defaultNestedValues: Object.freeze({
+        fakeNestedArr2: [FakeNested],
+        fakeNestedArr: BulletProps2?.__defaultNestedValues.fakeNestedArr,
+        tooltip: BulletProps2?.__defaultNestedValues.tooltip,
+        someProp: BulletProps2?.__defaultNestedValues.someProp,
+      }) as any,
     })
   )
 );

--- a/packages/tests/unit-tests/test-cases/expected/react/nested-pick.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/nested-pick.tsx
@@ -12,9 +12,7 @@ export declare type BasePropsType = {
   children?: React.ReactNode;
 };
 export const BaseProps: BasePropsType = {
-  get __defaultNestedValues() {
-    return { nestedProp: {} };
-  },
+  __defaultNestedValues: Object.freeze({ nestedProp: {} }) as any,
 };
 export declare type SomePropsType = {
   nestedProp?: typeof NestedProps;
@@ -25,7 +23,7 @@ export declare type SomePropsType = {
   fieldComponent?: () => null;
 };
 export const SomeProps: SomePropsType = {
-  get __defaultNestedValues() {
-    return { nestedProp: BaseProps.nestedProp };
-  },
+  __defaultNestedValues: Object.freeze({
+    nestedProp: BaseProps.nestedProp,
+  }) as any,
 };

--- a/packages/tests/unit-tests/test-cases/expected/react/nested-props-and-component.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/nested-props-and-component.tsx
@@ -27,9 +27,9 @@ export declare type WidgetPropsType = {
   children?: React.ReactNode;
 };
 export const WidgetProps: WidgetPropsType = {
-  get __defaultNestedValues() {
-    return { anotherNestedPropInit: [FakeNested] };
-  },
+  __defaultNestedValues: Object.freeze({
+    anotherNestedPropInit: [FakeNested],
+  }) as any,
   twoWayPropChange: () => {},
 };
 import { __collectChildren, equalByValue } from "@devextreme/runtime/react";

--- a/packages/tests/unit-tests/test-cases/expected/react/nested-props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/nested-props.tsx
@@ -40,13 +40,11 @@ export declare type WidgetPropsType = {
   children?: React.ReactNode;
 };
 export const WidgetProps: WidgetPropsType = {
-  get __defaultNestedValues() {
-    return {
-      editing: EditingProps.__defaultNestedValues
-        ? EditingProps.__defaultNestedValues
-        : EditingProps,
-    };
-  },
+  __defaultNestedValues: Object.freeze({
+    editing: EditingProps.__defaultNestedValues
+      ? EditingProps.__defaultNestedValues
+      : EditingProps,
+  }) as any,
 };
 export declare type PickedPropsType = {
   columns?: Array<typeof GridColumnProps | string>;
@@ -55,7 +53,5 @@ export declare type PickedPropsType = {
   children?: React.ReactNode;
 };
 export const PickedProps: PickedPropsType = {
-  get __defaultNestedValues() {
-    return { editing: WidgetProps.editing };
-  },
+  __defaultNestedValues: Object.freeze({ editing: WidgetProps.editing }) as any,
 };

--- a/packages/tests/unit-tests/test-cases/expected/react/props.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/props.tsx
@@ -18,6 +18,7 @@ export declare type WidgetInputType = {
   height: number;
   export: object;
   array: any;
+  currentDate: any;
   expressionDefault: string;
   expressionDefault1: boolean;
   expressionDefault2: boolean | string;
@@ -30,12 +31,9 @@ export declare type WidgetInputType = {
 };
 export const WidgetInput: WidgetInputType = {
   height: 10,
-  get export() {
-    return {};
-  },
-  get array() {
-    return ["1"];
-  },
+  export: Object.freeze({}) as any,
+  array: Object.freeze(["1"]) as any,
+  currentDate: Object.freeze(new Date()) as any,
   get expressionDefault() {
     return device === "ios" ? "yes" : "no";
   },
@@ -102,6 +100,7 @@ export default function Widget(props: typeof WidgetInput & RestProps) {
     function __restAttributes(): RestProps {
       const {
         array,
+        currentDate,
         defaultStringValue,
         export: exportProp,
         expressionDefault,

--- a/packages/tests/unit-tests/test-cases/expected/react/spread-in-view.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/spread-in-view.tsx
@@ -8,9 +8,7 @@ export declare type WidgetPropsType = {
   onClick?: (e: any) => void;
 };
 export const WidgetProps: WidgetPropsType = {
-  get a() {
-    return [1, 2, 3];
-  },
+  a: Object.freeze([1, 2, 3]) as any,
   id: "1",
 };
 import * as React from "react";

--- a/packages/tests/unit-tests/test-cases/expected/react/types-external.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/types-external.tsx
@@ -20,16 +20,10 @@ export declare type WidgetPropsType = {
 export const WidgetProps: WidgetPropsType = {
   data: "data",
   union: "uniontext",
-  get obj() {
-    return { number: 123, text: "sda" };
-  },
-  get strArr() {
-    return ["ba", "ab"];
-  },
+  obj: Object.freeze({ number: 123, text: "sda" }) as any,
+  strArr: Object.freeze(["ba", "ab"]) as any,
   s: "",
-  get strDate() {
-    return new Date();
-  },
+  strDate: Object.freeze(new Date()) as any,
 };
 import * as React from "react";
 import { useCallback } from "react";

--- a/packages/tests/unit-tests/test-cases/expected/react/types.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/types.tsx
@@ -30,30 +30,18 @@ export const WidgetProps: WidgetPropsType = {
   str: "",
   num: 1,
   bool: true,
-  get arr() {
-    return [];
-  },
-  get strArr() {
-    return ["a", "b"];
-  },
-  get obj() {
-    return {};
-  },
-  get date() {
-    return new Date();
-  },
+  arr: Object.freeze([]) as any,
+  strArr: Object.freeze(["a", "b"]) as any,
+  obj: Object.freeze({}) as any,
+  date: Object.freeze(new Date()) as any,
   func: () => {},
   get symbol() {
     return Symbol("x");
   },
   externalEnum: "data",
   externalUnion: 0,
-  get externalObj() {
-    return { number: 0, text: "text" };
-  },
-  get externalArray() {
-    return ["s1", "s2"];
-  },
+  externalObj: Object.freeze({ number: 0, text: "text" }) as any,
+  externalArray: Object.freeze(["s1", "s2"]) as any,
   externalString: "someValue",
 };
 import * as React from "react";

--- a/packages/tests/unit-tests/test-cases/expected/vue/props.vue
+++ b/packages/tests/unit-tests/test-cases/expected/vue/props.vue
@@ -27,6 +27,11 @@ export const WidgetInput = {
       return ["1"];
     },
   },
+  currentDate: {
+    default() {
+      return new Date();
+    },
+  },
   expressionDefault: {
     type: String,
     default() {
@@ -72,6 +77,7 @@ export const DxWidget = {
         height: this.height,
         export: this.export,
         array: this.array,
+        currentDate: this.currentDate,
         expressionDefault: this.expressionDefault,
         expressionDefault1: this.expressionDefault1,
         expressionDefault2: this.expressionDefault2,


### PR DESCRIPTION
Calling getters recreate default value and leads to unexpected rerenders