### PR TITLE
Angular: Fix using array binding pattern in template parameters

### DIFF
--- a/packages/angular-generator/src/expressions/jsx/jsx-opening-element.ts
+++ b/packages/angular-generator/src/expressions/jsx/jsx-opening-element.ts
@@ -68,7 +68,7 @@ function functionParameterToTemplateVariables(
 
   if (parameter.name instanceof BindingPattern) {
     return parameter.name.elements.map((element) => new AngularDirective(
-      new Identifier(`let-${element.name}`),
+      new Identifier(`let-${element.propertyName || element.name}`),
       new Identifier(`${element.propertyName || element.name}`),
     ));
   }

--- a/packages/tests/unit-tests/test-cases/declarations/src/dx-widget-with-template.tsx
+++ b/packages/tests/unit-tests/test-cases/declarations/src/dx-widget-with-template.tsx
@@ -3,6 +3,7 @@ import {
   Template,
   ComponentBindings,
   JSXComponent,
+  JSXTemplate,
 } from "@devextreme-generator/declarations";
 
 @ComponentBindings()
@@ -10,6 +11,7 @@ export class WidgetWithTemplateInput {
   @Template() template?: any;
   @Template() componentTemplate?: any;
   @Template() arrowTemplate?: any;
+  @Template() typedTemplate?: JSXTemplate<{ array: string[], obj: { text: string } }, 'array' | 'obj'>;
 }
 
 @Component({

--- a/packages/tests/unit-tests/test-cases/declarations/src/template-pass.tsx
+++ b/packages/tests/unit-tests/test-cases/declarations/src/template-pass.tsx
@@ -26,6 +26,11 @@ function view(model: Widget) {
           <div>{data.id}</div>
         )}
       />
+      <WidgetWithTemplate
+        typedTemplate={({ array: [param1, param2], obj: { text } }) => (
+          <div>{param1} {param2} {text}</div>
+        )}
+      />
     </Fragment>
   );
 }

--- a/packages/tests/unit-tests/test-cases/expected/angular/dx-widget-with-template.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/dx-widget-with-template.tsx
@@ -6,6 +6,7 @@ export class WidgetWithTemplateInput {
   @Input() template?: TemplateRef<any> | null = null;
   @Input() componentTemplate?: TemplateRef<any> | null = null;
   @Input() arrowTemplate?: TemplateRef<any> | null = null;
+  @Input() typedTemplate?: TemplateRef<any> | null = null;
 }
 
 import {
@@ -22,7 +23,7 @@ import { CommonModule } from "@angular/common";
 @Component({
   selector: "dx-widget-with-template",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  inputs: ["template", "componentTemplate", "arrowTemplate"],
+  inputs: ["template", "componentTemplate", "arrowTemplate", "typedTemplate"],
   template: `<ng-template #widgetTemplate
     ><div
       ><ng-container *ngTemplateOutlet="componentTemplate"></ng-container

--- a/packages/tests/unit-tests/test-cases/expected/angular/template-pass.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/angular/template-pass.tsx
@@ -69,6 +69,16 @@ import { CommonModule } from "@angular/common";
     ><ng-content
       *ngTemplateOutlet="widgetwithtemplate2?.widgetTemplate"
     ></ng-content
+    ><dx-widget-with-template
+      [typedTemplate]="__typedtemplate__generated1"
+      #widgetwithtemplate3
+      style="display: contents"
+      ><ng-template #__typedtemplate__generated1 let-array="array" let-obj="obj"
+        ><div>{{ array[0] }}{{ array[1] }}{{ obj.text }}</div></ng-template
+      ></dx-widget-with-template
+    ><ng-content
+      *ngTemplateOutlet="widgetwithtemplate3?.widgetTemplate"
+    ></ng-content
   ></ng-template>`,
 })
 export default class Widget extends WidgetProps {

--- a/packages/tests/unit-tests/test-cases/expected/react/dx-widget-with-template.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/dx-widget-with-template.tsx
@@ -2,12 +2,30 @@ export declare type WidgetWithTemplateInputType = {
   template?: any;
   componentTemplate?: any;
   arrowTemplate?: any;
+  typedTemplate?: React.FunctionComponent<
+    Partial<Omit<{ array: string[]; obj: { text: string } }, "array" | "obj">> &
+      Required<
+        Pick<{ array: string[]; obj: { text: string } }, "array" | "obj">
+      >
+  >;
   render?: any;
   component?: any;
   componentRender?: any;
   componentComponent?: any;
   arrowRender?: any;
   arrowComponent?: any;
+  typedRender?: React.FunctionComponent<
+    Partial<Omit<{ array: string[]; obj: { text: string } }, "array" | "obj">> &
+      Required<
+        Pick<{ array: string[]; obj: { text: string } }, "array" | "obj">
+      >
+  >;
+  typedComponent?: React.JSXElementConstructor<
+    Partial<Omit<{ array: string[]; obj: { text: string } }, "array" | "obj">> &
+      Required<
+        Pick<{ array: string[]; obj: { text: string } }, "array" | "obj">
+      >
+  >;
 };
 export const WidgetWithTemplateInput: WidgetWithTemplateInputType = {};
 import * as React from "react";
@@ -24,6 +42,7 @@ interface WidgetWithTemplate {
   props: typeof WidgetWithTemplateInput & RestProps;
   restAttributes: RestProps;
 }
+
 export default function WidgetWithTemplate(
   props: typeof WidgetWithTemplateInput & RestProps
 ) {
@@ -39,6 +58,9 @@ export default function WidgetWithTemplate(
         componentTemplate,
         render,
         template,
+        typedComponent,
+        typedRender,
+        typedTemplate,
         ...restProps
       } = props;
       return restProps;
@@ -59,6 +81,11 @@ export default function WidgetWithTemplate(
         props.arrowTemplate,
         props.arrowRender,
         props.arrowComponent
+      ),
+      typedTemplate: getTemplate(
+        props.typedTemplate,
+        props.typedRender,
+        props.typedComponent
       ),
     },
     restAttributes: __restAttributes(),

--- a/packages/tests/unit-tests/test-cases/expected/react/template-pass.tsx
+++ b/packages/tests/unit-tests/test-cases/expected/react/template-pass.tsx
@@ -19,6 +19,18 @@ function view(model: Widget) {
           <div>{data.id}</div>
         )}
       />
+
+      <WidgetWithTemplate
+        typedTemplate={({ array: [param1, param2], obj: { text } }) => (
+          <div>
+            {param1}
+
+            {param2}
+
+            {text}
+          </div>
+        )}
+      />
     </React.Fragment>
   );
 }

--- a/packages/tests/unit-tests/test-cases/expected/vue/template-pass.vue
+++ b/packages/tests/unit-tests/test-cases/expected/vue/template-pass.vue
@@ -16,6 +16,11 @@
       ><template v-slot:arrowTemplate="data"
         ><div>{{ data.id }}</div></template
       ></WidgetWithTemplate
+    ><WidgetWithTemplate
+      ><template
+        v-slot:typedTemplate="{ array: [param1, param2], obj: { text } }"
+        ><div>{{ array[0] }}{{ array[1] }}{{ text }}</div></template
+      ></WidgetWithTemplate
     ></div
   >
 </template>


### PR DESCRIPTION
Fix PR fixes the following template parameters:
```javascript
template={({
      deps: [pageIndex, pageSize, totalCount, pageCount],
    }): JSX.Element => (
```